### PR TITLE
Implement extended syscalls

### DIFF
--- a/core/kernel.ts
+++ b/core/kernel.ts
@@ -31,6 +31,22 @@ type Program = {
   main: (syscall: SyscallDispatcher, argv: string[]) => Promise<number>;
 };
 
+export interface SpawnOpts {
+  argv?: string[];
+  uid?: number;
+  gid?: number;
+}
+
+export type ServiceHandler = (data: Uint8Array) => Promise<Uint8Array | void>;
+
+export interface WindowOpts {
+  title?: string;
+  width?: number;
+  height?: number;
+  x?: number;
+  y?: number;
+}
+
 /**
  * A function that dispatches a syscall to the kernel for a specific process.
  */
@@ -43,11 +59,19 @@ export class Kernel {
   private fs: InMemoryFileSystem;
   private processes: Map<ProcessID, ProcessControlBlock>;
   private nextPid: ProcessID;
+  private services: Map<number, { proto: string; handler: ServiceHandler }>;
+  private sockets: Map<number, { ip: string; port: number }>;
+  private nextSocketId: number;
+  private windows: Array<{ html: Uint8Array; opts: WindowOpts }>;
 
   private constructor(fs: InMemoryFileSystem) {
     this.fs = fs;
     this.processes = new Map();
     this.nextPid = 1;
+    this.services = new Map();
+    this.sockets = new Map();
+    this.nextSocketId = 1;
+    this.windows = [];
   }
 
   public static async create(): Promise<Kernel> {
@@ -60,31 +84,19 @@ export class Kernel {
     const [progName, ...argv] = command.split(' ').filter(Boolean);
     const path = `/bin/${progName}`; // Assume programs are in /bin
 
-    let program: Program;
+    let source: string;
     try {
       const node = this.fs.getNode(path);
       if (!node || node.kind !== 'file' || !node.data) {
         throw new Error();
       }
-      const source = new TextDecoder().decode(node.data);
-      const mainFunc = new Function(`return ${source}`)();
-      program = { main: mainFunc };
+      source = new TextDecoder().decode(node.data);
     } catch (e) {
       console.error(`-helios: ${progName}: command not found`);
       return 127;
     }
 
-    const pid = this.createProcess();
-    const syscallDispatcher = this.createSyscallDispatcher(pid);
-
-    try {
-      return await program.main(syscallDispatcher, argv);
-    } catch (error) {
-      console.error(`Process ${pid} (${progName}) crashed:`, error);
-      return 1;
-    } finally {
-      this.cleanupProcess(pid);
-    }
+    return this.syscall_spawn(source, { argv });
   }
 
   private createProcess(): ProcessID {
@@ -120,6 +132,16 @@ export class Kernel {
           return this.syscall_write(pcb, args[0], args[1]);
         case 'close':
           return this.syscall_close(pcb, args[0]);
+        case 'spawn':
+          return this.syscall_spawn(args[0], args[1]);
+        case 'listen':
+          return this.syscall_listen(args[0], args[1], args[2]);
+        case 'connect':
+          return this.syscall_connect(args[0], args[1]);
+        case 'draw':
+          return this.syscall_draw(args[0], args[1]);
+        case 'snapshot':
+          return this.syscall_snapshot();
         default:
           throw new Error(`Unknown syscall: ${call}`);
       }
@@ -195,5 +217,69 @@ export class Kernel {
     }
     pcb.fds.delete(fd);
     return 0;
+  }
+
+  private async syscall_spawn(code: string, opts: SpawnOpts = {}): Promise<number> {
+    const pid = this.createProcess();
+    const pcb = this.processes.get(pid)!;
+    if (opts.uid !== undefined) pcb.uid = opts.uid;
+    if (opts.gid !== undefined) pcb.gid = opts.gid;
+
+    let program: Program;
+    try {
+      const mainFunc = new Function(`return ${code}`)();
+      program = { main: mainFunc };
+    } catch (e) {
+      this.cleanupProcess(pid);
+      throw e;
+    }
+
+    const syscallDispatcher = this.createSyscallDispatcher(pid);
+    const argv = opts.argv ?? [];
+    try {
+      return await program.main(syscallDispatcher, argv);
+    } catch (err) {
+      console.error(`Process ${pid} crashed:`, err);
+      return 1;
+    } finally {
+      this.cleanupProcess(pid);
+    }
+  }
+
+  private syscall_listen(port: number, proto: string, cb: ServiceHandler): number {
+    this.services.set(port, { proto, handler: cb });
+    return port;
+  }
+
+  private syscall_connect(ip: string, port: number): number {
+    const id = this.nextSocketId++;
+    this.sockets.set(id, { ip, port });
+    return id;
+  }
+
+  private syscall_draw(html: Uint8Array, opts: WindowOpts): number {
+    this.windows.push({ html, opts });
+    return this.windows.length - 1;
+  }
+
+  private syscall_snapshot(): any {
+    const replacer = (_: string, value: any) => {
+      if (value instanceof Map) {
+        return { dataType: 'Map', value: Array.from(value.entries()) };
+      }
+      return value;
+    };
+
+    const fsSnapshot = (this.fs as any).serialize();
+    const state = {
+      fs: fsSnapshot,
+      processes: this.processes,
+      services: this.services,
+      sockets: this.sockets,
+      windows: this.windows,
+      nextPid: this.nextPid,
+      nextSocketId: this.nextSocketId,
+    };
+    return JSON.parse(JSON.stringify(state, replacer));
   }
 }


### PR DESCRIPTION
## Summary
- add syscall helper methods for spawn, listen, connect, draw and snapshot
- extend syscall dispatcher to route new calls
- unify terminal spawning with syscall_spawn
- store simple service, socket and window state for snapshotting
- serialize entire kernel state via new snapshot syscall

## Testing
- `pnpm install`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6843a64b94a8832499ebc86848d7ac82