### PR TITLE
Add basic service framework

### DIFF
--- a/apps/browser.ts
+++ b/apps/browser.ts
@@ -1,0 +1,9 @@
+import { Kernel } from '../core/kernel';
+import { startHttpd } from '../core/services/http';
+
+export async function runBrowserExample(kernel: Kernel) {
+  startHttpd(kernel, { port: 8080 });
+  // Connect to the local HTTP service and issue a simple request
+  const sock = (kernel as any).tcp.connect('127.0.0.1', 8080);
+  (kernel as any).tcp.send(sock, new TextEncoder().encode('GET / HTTP/1.1\r\n\r\n'));
+}

--- a/apps/index.ts
+++ b/apps/index.ts
@@ -1,1 +1,2 @@
- 
+export * from './browser';
+export * from './sshClient';

--- a/apps/sshClient.ts
+++ b/apps/sshClient.ts
@@ -1,0 +1,9 @@
+import { Kernel } from '../core/kernel';
+import { startSshd } from '../core/services/ssh';
+
+export async function runSshExample(kernel: Kernel) {
+  startSshd(kernel, { port: 2222 });
+  // Connect to the local SSH service
+  const sock = (kernel as any).tcp.connect('127.0.0.1', 2222);
+  (kernel as any).tcp.send(sock, new TextEncoder().encode('\n'));
+}

--- a/core/net/tcp.ts
+++ b/core/net/tcp.ts
@@ -10,6 +10,10 @@ export class TCP {
     return port;
   }
 
+  unlisten(port: number): void {
+    this.listeners.delete(port);
+  }
+
   connect(ip: string, port: number): number {
     const id = this.nextSocket++;
     this.sockets.set(id, { ip, port });

--- a/core/net/udp.ts
+++ b/core/net/udp.ts
@@ -10,6 +10,10 @@ export class UDP {
     return port;
   }
 
+  unlisten(port: number): void {
+    this.listeners.delete(port);
+  }
+
   connect(ip: string, port: number): number {
     const id = this.nextSocket++;
     this.sockets.set(id, { ip, port });

--- a/core/services/http.ts
+++ b/core/services/http.ts
@@ -1,0 +1,15 @@
+import { Kernel, ServiceHandler } from '../kernel';
+
+export interface HttpOptions {
+  port?: number;
+}
+
+export function startHttpd(kernel: Kernel, opts: HttpOptions = {}): void {
+  const port = opts.port ?? 80;
+  const handler: ServiceHandler = async data => {
+    const req = new TextDecoder().decode(data);
+    const response = `HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nHello from Helios HTTP on port ${port}\n`;
+    return new TextEncoder().encode(response);
+  };
+  kernel.registerService(`httpd:${port}`, port, 'tcp', handler);
+}

--- a/core/services/index.ts
+++ b/core/services/index.ts
@@ -1,0 +1,2 @@
+export * from './http';
+export * from './ssh';

--- a/core/services/ssh.ts
+++ b/core/services/ssh.ts
@@ -1,0 +1,19 @@
+import { Kernel, ServiceHandler } from '../kernel';
+
+export interface SshOptions {
+  port?: number;
+}
+
+export function startSshd(kernel: Kernel, opts: SshOptions = {}): void {
+  const port = opts.port ?? 22;
+  const greeting = new TextEncoder().encode('Welcome to Helios SSH\n');
+  const handler: ServiceHandler = async data => {
+    const cmd = new TextDecoder().decode(data).trim();
+    if (cmd.length === 0) {
+      return greeting;
+    }
+    const resp = new TextEncoder().encode('Unknown command\n');
+    return resp;
+  };
+  kernel.registerService(`sshd:${port}`, port, 'tcp', handler);
+}


### PR DESCRIPTION
## Summary
- implement a minimal services layer under `core/services`
- new HTTP and SSH daemon helpers using `kernel.registerService`
- track and manage running services via `Kernel`
- add unlisten support for TCP/UDP
- provide example apps that start and use the new services

## Testing
- `pnpm build` *(fails: esbuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843b2ce39048324932787f128de43ba