### PR TITLE
Add basic nano and browser apps

### DIFF
--- a/apps/index.ts
+++ b/apps/index.ts
@@ -1,2 +1,12 @@
 export * from './browser';
 export * from './sshClient';
+export * from './nano';
+export * from './webBrowser';
+
+import { NANO_SOURCE } from './nano';
+import { BROWSER_SOURCE } from './webBrowser';
+
+export const BUNDLED_APPS = new Map<string, string>([
+  ['nano', NANO_SOURCE],
+  ['browser', BROWSER_SOURCE],
+]);

--- a/apps/nano.ts
+++ b/apps/nano.ts
@@ -1,0 +1,30 @@
+export const NANO_SOURCE = `
+  async (syscall, argv) => {
+    const STDERR_FD = 2;
+    const encode = (s) => new TextEncoder().encode(s);
+    if (argv.length === 0) {
+      await syscall('write', STDERR_FD, encode('nano: missing file\n'));
+      return 1;
+    }
+    const path = argv[0];
+    let content = '';
+    try {
+      const fd = await syscall('open', path, 'r');
+      while (true) {
+        const chunk = await syscall('read', fd, 1024);
+        if (chunk.length === 0) break;
+        content += new TextDecoder().decode(chunk);
+      }
+      await syscall('close', fd);
+    } catch (e) {
+      // new file - start empty
+    }
+    const escaped = content
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+    const html = '<pre>' + escaped + '</pre>';
+    await syscall('draw', new TextEncoder().encode(html), { title: 'nano - ' + path });
+    return 0;
+  }
+`;

--- a/apps/webBrowser.ts
+++ b/apps/webBrowser.ts
@@ -1,0 +1,14 @@
+export const BROWSER_SOURCE = `
+  async (syscall, argv) => {
+    const STDERR_FD = 2;
+    const encode = (s) => new TextEncoder().encode(s);
+    if (argv.length === 0) {
+      await syscall('write', STDERR_FD, encode('browser: missing url\n'));
+      return 1;
+    }
+    const url = argv[0];
+    const html = '<h1>Requested URL: ' + url + '</h1>';
+    await syscall('draw', new TextEncoder().encode(html), { title: 'browser' });
+    return 0;
+  }
+`;

--- a/core/fs/bin.ts
+++ b/core/fs/bin.ts
@@ -80,3 +80,49 @@ export const ECHO_SOURCE = `
     return 0;
   }
 `; 
+export const NANO_SOURCE = `
+  async (syscall, argv) => {
+    const STDERR_FD = 2;
+    const encode = (s) => new TextEncoder().encode(s);
+    if (argv.length === 0) {
+      await syscall('write', STDERR_FD, encode('nano: missing file\n'));
+      return 1;
+    }
+    const path = argv[0];
+    let content = '';
+    try {
+      const fd = await syscall('open', path, 'r');
+      while (true) {
+        const chunk = await syscall('read', fd, 1024);
+        if (chunk.length === 0) break;
+        content += new TextDecoder().decode(chunk);
+      }
+      await syscall('close', fd);
+    } catch (e) {
+      // new file - start empty
+    }
+    const escaped = content
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+    const html = '<pre>' + escaped + '</pre>';
+    await syscall('draw', new TextEncoder().encode(html), { title: 'nano - ' + path });
+    return 0;
+  }
+`;
+
+export const BROWSER_SOURCE = `
+  async (syscall, argv) => {
+    const STDERR_FD = 2;
+    const encode = (s) => new TextEncoder().encode(s);
+    if (argv.length === 0) {
+      await syscall('write', STDERR_FD, encode('browser: missing url\n'));
+      return 1;
+    }
+    const url = argv[0];
+    const html = '<h1>Requested URL: ' + url + '</h1>';
+    await syscall('draw', new TextEncoder().encode(html), { title: 'browser' });
+    return 0;
+  }
+`;
+

--- a/core/fs/index.ts
+++ b/core/fs/index.ts
@@ -1,4 +1,4 @@
-import { ECHO_SOURCE, CAT_SOURCE } from './bin';
+import { ECHO_SOURCE, CAT_SOURCE, NANO_SOURCE, BROWSER_SOURCE } from './bin';
 import { createPersistHook } from './sqlite';
 
 /**
@@ -70,6 +70,8 @@ export class InMemoryFileSystem {
     this.createDirectory('/bin', 0o755);
     this.createFile('/bin/cat', CAT_SOURCE, 0o755);
     this.createFile('/bin/echo', ECHO_SOURCE, 0o755);
+    this.createFile('/bin/nano', NANO_SOURCE, 0o755);
+    this.createFile('/bin/browser', BROWSER_SOURCE, 0o755);
 
     const bundled = (globalThis as any).BUNDLED_DISK_IMAGES as
       | Array<{ image: FileSystemSnapshot; path: string }>


### PR DESCRIPTION
## Summary
- create minimal nano-like editor and web browser
- install new programs in `/bin`
- export bundled apps map for convenience

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6843b3f31b948324953908811f0a601c