### PR TITLE
Add kernel snapshot/restore support

### DIFF
--- a/core/fs/sqlite.ts
+++ b/core/fs/sqlite.ts
@@ -23,3 +23,21 @@ export function createPersistHook(): PersistHook {
     persistSnapshot(snapshot);
   };
 }
+
+// Full kernel snapshot helpers
+export async function loadKernelSnapshot(): Promise<any | null> {
+  try {
+    const result = await invoke<any>('load_snapshot');
+    return result as any;
+  } catch {
+    return null;
+  }
+}
+
+export async function persistKernelSnapshot(snapshot: any) {
+  try {
+    await invoke('save_snapshot', { json: JSON.stringify(snapshot) });
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
## Summary
- support saving/loading kernel-wide snapshot data
- implement `Kernel.snapshot()` and `Kernel.restore()` to serialize/rehydrate state
- add Tauri commands to persist or fetch a snapshot

## Testing
- `npm run build` *(fails: esbuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843b754d794832488db8409007f6b2a