### PR TITLE
Wire kernel syscalls into v8 isolates

### DIFF
--- a/apps/echo.ts
+++ b/apps/echo.ts
@@ -1,1 +1,5 @@
- 
+import { Kernel } from '../core/kernel';
+
+export async function runEchoExample(kernel: Kernel) {
+  await kernel.spawn('echo hello from syscall');
+}

--- a/apps/index.ts
+++ b/apps/index.ts
@@ -2,6 +2,7 @@ export * from './browser';
 export * from './sshClient';
 export * from './nano';
 export * from './webBrowser';
+export * from './echo';
 
 import { NANO_SOURCE } from './nano';
 import { BROWSER_SOURCE } from './webBrowser';

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -1,10 +1,13 @@
 use rusqlite::{params, Connection, OptionalExtension};
 use serde_json::Value;
-use std::sync::Once;
+use std::collections::HashMap;
+use std::sync::{mpsc, Mutex, Once};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use tauri::api::path::app_dir;
 use tokio::time::timeout;
 use v8;
+use once_cell::sync::Lazy;
 
 #[tauri::command]
 fn save_snapshot(json: String) -> Result<(), String> {
@@ -69,6 +72,8 @@ fn load_fs() -> Result<Option<Value>, String> {
 }
 
 static INIT: Once = Once::new();
+static NEXT_ID: AtomicUsize = AtomicUsize::new(1);
+static RESPONSES: Lazy<Mutex<HashMap<usize, mpsc::Sender<Value>>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 
 fn init_v8() {
     INIT.call_once(|| {
@@ -79,13 +84,63 @@ fn init_v8() {
 }
 
 #[tauri::command]
-async fn run_isolate(code: String, quota_ms: u64, quota_mem: usize) -> Result<i32, String> {
+fn syscall_response(id: usize, result: Value) -> Result<(), String> {
+    if let Some(tx) = RESPONSES.lock().unwrap().remove(&id) {
+        tx.send(result).map_err(|_| "send failed".to_string())?;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+async fn run_isolate(app: tauri::AppHandle, code: String, quota_ms: u64, quota_mem: usize, pid: u32) -> Result<i32, String> {
     init_v8();
     let fut = tokio::task::spawn_blocking(move || {
         let mut isolate = v8::Isolate::new(v8::CreateParams::default().heap_limits(0, quota_mem));
         let handle_scope = &mut v8::HandleScope::new(&mut isolate);
         let context = v8::Context::new(handle_scope, Default::default());
         let scope = &mut v8::ContextScope::new(handle_scope, context);
+
+        // syscall callback
+        let app_clone = app.clone();
+        let syscall_tmpl = v8::FunctionTemplate::new(scope, move |scope, args, mut rv| {
+            let call_val = args.get(0);
+            let call = call_val.to_rust_string_lossy(scope);
+            let mut argv: Vec<Value> = Vec::new();
+            for i in 1..args.length() {
+                let v = args.get(i);
+                let value: Value = serde_v8::from_v8(scope, v).unwrap_or(Value::Null);
+                argv.push(value);
+            }
+
+            let id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
+            let (tx, rx) = mpsc::channel();
+            RESPONSES.lock().unwrap().insert(id, tx);
+
+            let payload = serde_json::json!({
+                "id": id,
+                "pid": pid,
+                "call": call,
+                "args": argv,
+            });
+            let _ = app_clone.emit_all("syscall", payload);
+
+            let resolver = v8::PromiseResolver::new(scope).unwrap();
+            let promise = resolver.get_promise(scope);
+            rv.set(promise.into());
+
+            if let Ok(result) = rx.recv() {
+                let value = serde_v8::to_v8(scope, result).unwrap_or_else(|_| v8::undefined(scope).into());
+                resolver.resolve(scope, value);
+            } else {
+                let err = v8::String::new(scope, "syscall failed").unwrap();
+                resolver.reject(scope, err.into());
+            }
+        });
+        let syscall_func = syscall_tmpl.get_function(scope).unwrap();
+        let global = context.global(scope);
+        let key = v8::String::new(scope, "syscall").unwrap();
+        global.set(scope, key.into(), syscall_func.into());
+
         let code_str = v8::String::new(scope, &code).ok_or("bad code")?;
         let script = v8::Script::compile(scope, code_str, None).ok_or("compile")?;
         let value = script.run(scope).ok_or("run")?;
@@ -105,7 +160,8 @@ fn main() {
             load_fs,
             save_snapshot,
             load_snapshot,
-            run_isolate
+            run_isolate,
+            syscall_response
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
## Summary
- expose kernel syscall dispatcher to isolate execution
- implement syscall event bridge in the host
- add a small `runEchoExample` program

## Testing
- `pnpm build`
- `cargo check` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6843bcbe2cd48324a076f88ca57bf044