### PR TITLE
Fix snapshot deserialisation

### DIFF
--- a/core/fs/index.test.ts
+++ b/core/fs/index.test.ts
@@ -1,0 +1,16 @@
+import assert from 'assert';
+import { InMemoryFileSystem } from './index';
+
+function run() {
+  const fs1 = new InMemoryFileSystem();
+  fs1.createDirectory('/test', 0o755);
+  fs1.createFile('/test/file.txt', 'hello', 0o644);
+  // take snapshot via private serialize method
+  const snapshot = (fs1 as any).serialize();
+
+  const fs2 = new InMemoryFileSystem(snapshot);
+  assert(fs2.getNode('/test/file.txt'), 'file should exist after loading snapshot');
+}
+
+run();
+console.log('Snapshot load test passed.');

--- a/core/fs/index.ts
+++ b/core/fs/index.ts
@@ -52,8 +52,9 @@ export class InMemoryFileSystem {
     this.persistHook = persistHook;
     this.mounts = new Map();
     if (snapshot) {
-        this.root = this.deserialize(snapshot).root;
-        this.nodes = this.deserialize(snapshot).nodes;
+        const { root, nodes } = this.deserialize(snapshot);
+        this.root = root;
+        this.nodes = nodes;
         return;
     }
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev:host": "sleep 5 && cd host && tauri dev",
     "build": "esbuild ui/index.tsx --bundle --outfile=dist/bundle.js --target=esnext --platform=browser",
     "build:release": "pnpm build && cd host && tauri build",
-    "helios": "ts-node tools/helios.ts"
+    "helios": "ts-node tools/helios.ts",
+    "test": "esbuild core/fs/index.test.ts --bundle --platform=node --format=cjs --outfile=core/fs/index.test.js && node core/fs/index.test.js && rm core/fs/index.test.js"
   },
   "dependencies": {
     "@pablo-lion/xterm-react": "^1.1.2",


### PR DESCRIPTION
## Summary
- avoid double deserialisation when loading filesystem snapshots
- add unit test to check snapshot loading

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6843bebfae988324923a9399ae78048f