### PR TITLE
Add getSnapshot method to filesystem

### DIFF
--- a/core/fs/index.test.ts
+++ b/core/fs/index.test.ts
@@ -5,8 +5,8 @@ function run() {
   const fs1 = new InMemoryFileSystem();
   fs1.createDirectory('/test', 0o755);
   fs1.createFile('/test/file.txt', 'hello', 0o644);
-  // take snapshot via private serialize method
-  const snapshot = (fs1 as any).serialize();
+  // take snapshot using public API
+  const snapshot = fs1.getSnapshot();
 
   const fs2 = new InMemoryFileSystem(snapshot);
   assert(fs2.getNode('/test/file.txt'), 'file should exist after loading snapshot');

--- a/core/fs/index.ts
+++ b/core/fs/index.ts
@@ -217,6 +217,13 @@ export class InMemoryFileSystem {
     return this.nodes.get(path);
   }
 
+  /**
+   * Returns a serializable snapshot of the file system.
+   */
+  public getSnapshot(): FileSystemSnapshot {
+    return this.serialize();
+  }
+
   public mount(image: FileSystemSnapshot, path: string): void {
     const snap = this.deserialize(image);
     let mountPoint = this.nodes.get(path);

--- a/core/kernel.ts
+++ b/core/kernel.ts
@@ -422,7 +422,7 @@ export class Kernel {
       return value;
     };
 
-    const fsSnapshot = (this.fs as any).serialize();
+    const fsSnapshot = this.fs.getSnapshot();
     const state: Snapshot = {
       fs: fsSnapshot,
       processes: this.processes,


### PR DESCRIPTION
## Summary
- expose a `getSnapshot()` method in `InMemoryFileSystem`
- use the new API in `Kernel.snapshot`
- update tests to call `getSnapshot`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684447758df88324a024d38cbd2edb50