### PR TITLE
Add Kernel stop method and tests

### DIFF
--- a/core/kernel.test.ts
+++ b/core/kernel.test.ts
@@ -1,0 +1,19 @@
+import assert from 'assert';
+import { Kernel } from './kernel';
+import { InMemoryFileSystem } from './fs';
+
+async function run() {
+  const kernel: any = new (Kernel as any)(new InMemoryFileSystem());
+  // Override runProcess to simulate asynchronous process running
+  let ran = false;
+  kernel.runProcess = async (pcb: any) => { ran = true; pcb.exited = true; };
+  await kernel['syscall_spawn']('dummy');
+  const startPromise = kernel.start();
+  // wait a tick then stop
+  setTimeout(() => kernel.stop(), 10);
+  await startPromise;
+  assert(ran, 'process should run');
+  console.log('Kernel scheduler stop test passed.');
+}
+
+run();

--- a/core/kernel.ts
+++ b/core/kernel.ts
@@ -472,4 +472,8 @@ export class Kernel {
       }
     }
   }
+
+  public stop(): void {
+    this.running = false;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "esbuild ui/index.tsx --bundle --outfile=dist/bundle.js --target=esnext --platform=browser --tsconfig=tsconfig.json",
     "build:release": "pnpm build && cd host && tauri build",
     "helios": "ts-node --project tsconfig.json tools/helios.ts",
-    "test": "esbuild core/fs/index.test.ts --bundle --platform=node --format=cjs --tsconfig=tsconfig.json --outfile=core/fs/index.test.js && node core/fs/index.test.js && rm core/fs/index.test.js"
+    "test": "esbuild core/fs/index.test.ts --bundle --platform=node --format=cjs --tsconfig=tsconfig.json --outfile=core/fs/index.test.js && node core/fs/index.test.js && rm core/fs/index.test.js && esbuild core/kernel.test.ts --bundle --platform=node --format=cjs --tsconfig=tsconfig.json --outfile=core/kernel.test.js && node core/kernel.test.js && rm core/kernel.test.js"
   },
   "dependencies": {
     "@pablo-lion/xterm-react": "^1.1.2",


### PR DESCRIPTION
## Summary
- add `Kernel.stop()` to halt scheduler
- extend test script to include new kernel test
- add scheduler unit test verifying `stop()` stops the loop

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68444d0892a083248a6ebc015e9e4db8