### PR TITLE
Add typed events to EventBus

### DIFF
--- a/core/eventBus.ts
+++ b/core/eventBus.ts
@@ -1,23 +1,35 @@
+import type { WindowOpts } from './kernel';
+
+export interface DrawPayload {
+  id: number;
+  html: string;
+  opts: WindowOpts;
+}
+
+export interface EventMap {
+  draw: DrawPayload;
+}
+
 export type Handler<T = any> = (payload: T) => void;
 
-class EventBus {
-  private handlers: Record<string, Handler[]> = {};
+class EventBus<Events extends Record<string, any>> {
+  private handlers: { [K in keyof Events]?: Handler<Events[K]>[] } = {};
 
-  on(event: string, handler: Handler) {
+  on<K extends keyof Events>(event: K, handler: Handler<Events[K]>) {
     if (!this.handlers[event]) {
       this.handlers[event] = [];
     }
-    this.handlers[event].push(handler);
+    this.handlers[event]!.push(handler);
   }
 
-  off(event: string, handler: Handler) {
+  off<K extends keyof Events>(event: K, handler: Handler<Events[K]>) {
     if (!this.handlers[event]) return;
-    this.handlers[event] = this.handlers[event].filter(h => h !== handler);
+    this.handlers[event] = this.handlers[event]!.filter(h => h !== handler);
   }
 
-  emit(event: string, payload: any) {
+  emit<K extends keyof Events>(event: K, payload: Events[K]) {
     (this.handlers[event] || []).forEach(h => h(payload));
   }
 }
 
-export const eventBus = new EventBus();
+export const eventBus = new EventBus<EventMap>();

--- a/ui/index.tsx
+++ b/ui/index.tsx
@@ -5,9 +5,9 @@ import { ITheme } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import 'react-resizable/css/styles.css';
 
-import { Kernel, WindowOpts } from '../core/kernel';
+import { Kernel } from '../core/kernel';
 import { WindowManager, WindowManagerHandles } from './components/WindowManager';
-import { eventBus } from '../core/eventBus';
+import { eventBus, type DrawPayload } from '../core/eventBus';
 
 // A basic theme for the terminal
 const theme: ITheme = {
@@ -74,7 +74,7 @@ const App = () => {
     }, []);
 
     useEffect(() => {
-        const handler = (payload: { id: number; html: string; opts: WindowOpts }) => {
+        const handler = (payload: DrawPayload) => {
             windowManagerRef.current?.openWindow({
                 id: payload.id,
                 title: payload.opts.title,


### PR DESCRIPTION
## Summary
- define `DrawPayload` and `EventMap`
- make `EventBus` generic over event map
- update `ui/index.tsx` to use typed handler

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68444e2f70f0832493199ecb131b4557