### PR TITLE
Refactor Tauri DB helpers

### DIFF
--- a/host/src/db.rs
+++ b/host/src/db.rs
@@ -1,0 +1,73 @@
+use rusqlite::Connection;
+use tauri::api::dialog;
+use tauri::api::path::app_dir;
+
+/// Open the snapshot database connection creating the DB if needed.
+/// Errors are logged using a dialog message.
+pub fn snapshot() -> Result<Connection, String> {
+    let dir = match app_dir(&tauri::Config::default()) {
+        Some(d) => d,
+        None => {
+            dialog::message(None, "Database Error", "no app dir");
+            return Err("no app dir".into());
+        }
+    };
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        let msg = e.to_string();
+        dialog::message(None, "Database Error", &msg);
+        return Err(msg);
+    }
+    let db_path = dir.join("snapshot.db");
+    let conn = match Connection::open(db_path) {
+        Ok(c) => c,
+        Err(e) => {
+            let msg = e.to_string();
+            dialog::message(None, "Database Error", &msg);
+            return Err(msg);
+        }
+    };
+    if let Err(e) = conn.execute(
+        "CREATE TABLE IF NOT EXISTS snapshot_state (id INTEGER PRIMARY KEY, json TEXT)",
+        [],
+    ) {
+        let msg = e.to_string();
+        dialog::message(None, "Database Error", &msg);
+        return Err(msg);
+    }
+    Ok(conn)
+}
+
+/// Open the filesystem database connection creating the DB if needed.
+/// Errors are logged using a dialog message.
+pub fn fs() -> Result<Connection, String> {
+    let dir = match app_dir(&tauri::Config::default()) {
+        Some(d) => d,
+        None => {
+            dialog::message(None, "Database Error", "no app dir");
+            return Err("no app dir".into());
+        }
+    };
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        let msg = e.to_string();
+        dialog::message(None, "Database Error", &msg);
+        return Err(msg);
+    }
+    let db_path = dir.join("fs.db");
+    let conn = match Connection::open(db_path) {
+        Ok(c) => c,
+        Err(e) => {
+            let msg = e.to_string();
+            dialog::message(None, "Database Error", &msg);
+            return Err(msg);
+        }
+    };
+    if let Err(e) = conn.execute(
+        "CREATE TABLE IF NOT EXISTS fs_state (id INTEGER PRIMARY KEY, json TEXT)",
+        [],
+    ) {
+        let msg = e.to_string();
+        dialog::message(None, "Database Error", &msg);
+        return Err(msg);
+    }
+    Ok(conn)
+}


### PR DESCRIPTION
## Summary
- add new `db` module for opening snapshot and fs SQLite databases
- log connection errors using `tauri::api::dialog::message`
- reuse helper functions in Tauri commands

## Testing
- `cargo fmt`
- `cargo check` *(fails: javascriptcoregtk-4.0.pc missing)*

------
https://chatgpt.com/codex/tasks/task_e_684454679dfc8324b7fce842e5ec1c24