### PR TITLE
Add unmount support to in-memory FS

### DIFF
--- a/core/fs/index.test.ts
+++ b/core/fs/index.test.ts
@@ -1,16 +1,39 @@
 import assert from 'assert';
 import { InMemoryFileSystem } from './index';
 
-function run() {
-  const fs1 = new InMemoryFileSystem();
-  fs1.createDirectory('/test', 0o755);
-  fs1.createFile('/test/file.txt', 'hello', 0o644);
-  // take snapshot using public API
-  const snapshot = fs1.getSnapshot();
+function testSnapshot() {
+    const fs1 = new InMemoryFileSystem();
+    fs1.createDirectory('/test', 0o755);
+    fs1.createFile('/test/file.txt', 'hello', 0o644);
+    const snapshot = fs1.getSnapshot();
 
-  const fs2 = new InMemoryFileSystem(snapshot);
-  assert(fs2.getNode('/test/file.txt'), 'file should exist after loading snapshot');
+    const fs2 = new InMemoryFileSystem(snapshot);
+    assert(fs2.getNode('/test/file.txt'), 'file should exist after loading snapshot');
+    console.log('Snapshot load test passed.');
 }
 
-run();
-console.log('Snapshot load test passed.');
+function testUnmount() {
+    const img = new InMemoryFileSystem();
+    img.createFile('/foo.txt', 'bar', 0o644);
+    const snap = img.getSnapshot();
+
+    const fs = new InMemoryFileSystem();
+    fs.mount(snap, '/mnt');
+    assert(fs.getNode('/mnt/foo.txt'), 'file should exist after mount');
+    fs.unmount('/mnt');
+    assert(!fs.getNode('/mnt'), 'mount point removed after unmount');
+
+    fs.createDirectory('/mnt', 0o755);
+    fs.createFile('/mnt/existing.txt', 'baz', 0o644);
+    fs.mount(snap, '/mnt');
+    assert(fs.getNode('/mnt/foo.txt'), 'mounted file exists');
+    fs.unmount('/mnt');
+    assert(fs.getNode('/mnt/existing.txt'), 'existing file preserved');
+    assert(fs.getNode('/mnt'), 'mount point preserved');
+    assert(!fs.getNode('/mnt/foo.txt'), 'mounted file removed');
+    console.log('Unmount test passed.');
+}
+
+testSnapshot();
+testUnmount();
+


### PR DESCRIPTION
## Summary
- implement `unmount(path)` to remove mounted images
- track whether mount point directories were created on mount
- update filesystem tests to cover mounting and unmounting

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68445d8964f08324a784ca08d68f3217