### PR TITLE
Add network tests

### DIFF
--- a/core/net/index.test.ts
+++ b/core/net/index.test.ts
@@ -1,0 +1,64 @@
+import assert from 'assert';
+import { TCP } from './tcp';
+import { UDP } from './udp';
+import { NIC } from './nic';
+import { Switch } from './switch';
+import { Router } from './router';
+
+function testTcp() {
+    const tcp = new TCP();
+    let received: Uint8Array | null = null;
+    tcp.listen(8080, (data) => { received = data; });
+    const sock = tcp.connect('127.0.0.1', 8080);
+    const payload = new Uint8Array([1, 2, 3]);
+    tcp.send(sock, payload);
+    assert(received && received.length === 3 && received[0] === 1, 'TCP handler should receive data');
+    console.log('TCP listen/connect test passed.');
+}
+
+function testUdp() {
+    const udp = new UDP();
+    let from: { ip: string; port: number } | null = null;
+    udp.listen(53, (_data, src) => { from = src; });
+    const sock = udp.connect('127.0.0.1', 53);
+    udp.send(sock, new Uint8Array([0]));
+    assert.deepStrictEqual(from, { ip: '127.0.0.1', port: 53 });
+    console.log('UDP handler source info test passed.');
+}
+
+function testSwitch() {
+    const sw = new Switch();
+    const a = new NIC('1', 'AA');
+    const b = new NIC('2', 'BB');
+    const c = new NIC('3', 'CC');
+    sw.connect(a);
+    sw.connect(b);
+    sw.connect(c);
+    // first send from A to B (unknown dst -> broadcast)
+    a.send({ src: 'AA', dst: 'BB', payload: new Uint8Array([1]) });
+    sw.tick();
+    assert(b.rx.length === 1 && c.rx.length === 1, 'broadcast on unknown destination');
+    b.rx.length = 0;
+    c.rx.length = 0;
+    // now send from B to A (known dst -> unicast)
+    b.send({ src: 'BB', dst: 'AA', payload: new Uint8Array([2]) });
+    sw.tick();
+    assert(a.rx.length === 1 && c.rx.length === 0, 'unicast on known destination');
+    console.log('Switch forwarding test passed.');
+}
+
+function testRouter() {
+    const router = new Router();
+    const nic1 = new NIC('1', 'AA');
+    const nic2 = new NIC('2', 'BB');
+    router.addRoute('192.168.1./24', nic2);
+    const frame = { src: '10.0.0.1', dst: '192.168.1.5', payload: new Uint8Array([3]) };
+    router.forward(frame);
+    assert(nic2.rx.length === 1 && nic2.rx[0] === frame, 'router forwards to correct NIC');
+    console.log('Router forward test passed.');
+}
+
+testTcp();
+testUdp();
+testSwitch();
+testRouter();

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "build": "esbuild ui/index.tsx --bundle --outfile=dist/bundle.js --target=esnext --platform=browser --tsconfig=tsconfig.json",
     "build:release": "pnpm build && cd host && tauri build",
     "helios": "tsx tools/helios.ts",
-    "test": "esbuild core/fs/index.test.ts --bundle --platform=node --format=cjs --tsconfig=tsconfig.json --outfile=core/fs/index.test.js && node core/fs/index.test.js && rm core/fs/index.test.js && esbuild core/kernel.test.ts --bundle --platform=node --format=cjs --tsconfig=tsconfig.json --outfile=core/kernel.test.js && node core/kernel.test.js && rm core/kernel.test.js"
-  },
+    "test": "esbuild core/fs/index.test.ts --bundle --platform=node --format=cjs --tsconfig=tsconfig.json --outfile=core/fs/index.test.js && node core/fs/index.test.js && rm core/fs/index.test.js && esbuild core/kernel.test.ts --bundle --platform=node --format=cjs --tsconfig=tsconfig.json --outfile=core/kernel.test.js && node core/kernel.test.js && rm core/kernel.test.js && esbuild core/net/index.test.ts --bundle --platform=node --format=cjs --tsconfig=tsconfig.json --outfile=core/net/index.test.js && node core/net/index.test.js && rm core/net/index.test.js"
+    },
   "dependencies": {
     "@pablo-lion/xterm-react": "^1.1.2",
     "@tauri-apps/api": "^1.5.3",


### PR DESCRIPTION
## Summary
- expand test coverage for core networking modules
- update test script to run new network tests

## Testing
- `pnpm i`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68445f43000c832496330bb4c98ddc02