### PR TITLE
Fix terminal artifact by importing xterm styles

### DIFF
--- a/ui/index.tsx
+++ b/ui/index.tsx
@@ -4,6 +4,7 @@ import { XTerm } from '@pablo-lion/xterm-react';
 import { ITheme } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import 'react-resizable/css/styles.css';
+import '@xterm/xterm/css/xterm.css';
 
 import { Kernel } from '../core/kernel';
 import { WindowManager, WindowManagerHandles } from './components/WindowManager';


### PR DESCRIPTION
## Summary
- include xterm.css so the terminal helper textarea is hidden

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6844d87a515c83248012a59d23387d32