### PR TITLE
Implement ping program and network send syscall

### DIFF
--- a/apps/index.ts
+++ b/apps/index.ts
@@ -2,10 +2,12 @@ export * from './browser';
 export * from './sshClient';
 export * from './nano';
 export * from './webBrowser';
+export * from './ping';
 
-import { NANO_SOURCE, BROWSER_SOURCE } from '../core/fs/bin';
+import { NANO_SOURCE, BROWSER_SOURCE, PING_SOURCE } from '../core/fs/bin';
 
 export const BUNDLED_APPS = new Map<string, string>([
   ['nano', NANO_SOURCE],
   ['browser', BROWSER_SOURCE],
+  ['ping', PING_SOURCE],
 ]);

--- a/apps/ping.ts
+++ b/apps/ping.ts
@@ -1,0 +1,2 @@
+export { PING_SOURCE } from '../core/fs/bin';
+

--- a/core/fs/bin.ts
+++ b/core/fs/bin.ts
@@ -126,6 +126,31 @@ export const BROWSER_SOURCE = `
   }
 `;
 
+export const PING_SOURCE = `
+  async (syscall, argv) => {
+    const STDOUT_FD = 1;
+    const STDERR_FD = 2;
+    const encode = (s) => new TextEncoder().encode(s);
+    const ip = argv[0] || '127.0.0.1';
+    const port = argv[1] ? parseInt(argv[1], 10) : 7;
+    try {
+      const sock = await syscall('connect', ip, port);
+      const start = Date.now();
+      const resp = await syscall('tcp_send', sock, encode('ping'));
+      const end = Date.now();
+      if (resp) {
+        await syscall('write', STDOUT_FD, encode('pong ' + (end - start) + 'ms\n'));
+      } else {
+        await syscall('write', STDERR_FD, encode('no response\n'));
+      }
+    } catch (e) {
+      await syscall('write', STDERR_FD, encode('ping: ' + e.message + '\n'));
+      return 1;
+    }
+    return 0;
+  }
+`;
+
 
 export const CAT_MANIFEST = JSON.stringify({
   name: 'cat',
@@ -145,5 +170,10 @@ export const NANO_MANIFEST = JSON.stringify({
 export const BROWSER_MANIFEST = JSON.stringify({
   name: 'browser',
   syscalls: ['draw']
+});
+
+export const PING_MANIFEST = JSON.stringify({
+  name: 'ping',
+  syscalls: ['connect', 'tcp_send', 'write']
 });
 

--- a/core/fs/index.ts
+++ b/core/fs/index.ts
@@ -3,10 +3,12 @@ import {
   CAT_SOURCE,
   NANO_SOURCE,
   BROWSER_SOURCE,
+  PING_SOURCE,
   CAT_MANIFEST,
   ECHO_MANIFEST,
   NANO_MANIFEST,
   BROWSER_MANIFEST,
+  PING_MANIFEST,
 } from './bin';
 import { createPersistHook } from './sqlite';
 
@@ -87,6 +89,8 @@ export class InMemoryFileSystem {
     this.createFile('/bin/nano.manifest.json', NANO_MANIFEST, 0o644);
     this.createFile('/bin/browser', BROWSER_SOURCE, 0o755);
     this.createFile('/bin/browser.manifest.json', BROWSER_MANIFEST, 0o644);
+    this.createFile('/bin/ping', PING_SOURCE, 0o755);
+    this.createFile('/bin/ping.manifest.json', PING_MANIFEST, 0o644);
 
     const bundled = (globalThis as any).BUNDLED_DISK_IMAGES as
       | Array<{ image: FileSystemSnapshot; path: string }>

--- a/core/kernel.ts
+++ b/core/kernel.ts
@@ -272,6 +272,10 @@ export class Kernel {
           return this.syscall_listen(args[0], args[1], args[2]);
         case 'connect':
           return this.syscall_connect(args[0], args[1]);
+        case 'tcp_send':
+          return this.syscall_tcp_send(args[0], args[1]);
+        case 'udp_send':
+          return this.syscall_udp_send(args[0], args[1]);
         case 'draw':
           return this.syscall_draw(args[0], args[1]);
         case 'snapshot':
@@ -404,6 +408,14 @@ export class Kernel {
 
   private syscall_connect(ip: string, port: number): number {
     return this.tcp.connect(ip, port);
+  }
+
+  private async syscall_tcp_send(sock: number, data: Uint8Array) {
+    return this.tcp.send(sock, data);
+  }
+
+  private async syscall_udp_send(sock: number, data: Uint8Array) {
+    return this.udp.send(sock, data);
   }
 
   private syscall_draw(html: Uint8Array, opts: WindowOpts): number {

--- a/core/net/index.test.ts
+++ b/core/net/index.test.ts
@@ -58,7 +58,22 @@ function testRouter() {
     console.log('Router forward test passed.');
 }
 
-testTcp();
-testUdp();
-testSwitch();
-testRouter();
+async function testTcpEcho() {
+    const tcp = new TCP();
+    tcp.listen(9000, data => data);
+    const sock = tcp.connect('127.0.0.1', 9000);
+    const payload = new Uint8Array([9, 8, 7]);
+    const resp = await tcp.send(sock, payload);
+    assert(resp && resp.length === 3 && resp[0] === 9, 'TCP send returns response');
+    console.log('TCP send response test passed.');
+}
+
+async function run() {
+    testTcp();
+    testUdp();
+    testSwitch();
+    testRouter();
+    await testTcpEcho();
+}
+
+run();

--- a/core/net/tcp.ts
+++ b/core/net/tcp.ts
@@ -20,12 +20,12 @@ export class TCP {
     return id;
   }
 
-  send(sock: number, data: Uint8Array) {
+  async send(sock: number, data: Uint8Array): Promise<Uint8Array | void> {
     const dst = this.sockets.get(sock);
     if (!dst) return;
     const handler = this.listeners.get(dst.port);
     if (handler) {
-      handler(data);
+      return await handler(data);
     }
   }
 }

--- a/core/net/udp.ts
+++ b/core/net/udp.ts
@@ -20,12 +20,12 @@ export class UDP {
     return id;
   }
 
-  send(sock: number, data: Uint8Array) {
+  async send(sock: number, data: Uint8Array): Promise<Uint8Array | void> {
     const dst = this.sockets.get(sock);
     if (!dst) return;
     const handler = this.listeners.get(dst.port);
     if (handler) {
-      handler(data, { ip: '127.0.0.1', port: dst.port });
+      return await handler(data, { ip: '127.0.0.1', port: dst.port });
     }
   }
 }

--- a/core/services/index.ts
+++ b/core/services/index.ts
@@ -1,2 +1,3 @@
 export * from './http';
 export * from './ssh';
+export * from './ping';

--- a/core/services/ping.ts
+++ b/core/services/ping.ts
@@ -1,0 +1,12 @@
+import { Kernel, ServiceHandler } from '../kernel';
+
+export interface PingOptions {
+  port?: number;
+}
+
+export function startPingService(kernel: Kernel, opts: PingOptions = {}): void {
+  const port = opts.port ?? 7;
+  const handler: ServiceHandler = async data => data;
+  kernel.registerService(`pingd:${port}`, port, 'tcp', handler);
+}
+


### PR DESCRIPTION
## Summary
- support ping daemon and network message round-trips
- expose `tcp_send` and `udp_send` syscalls
- provide a simple `ping` CLI program
- export ping application and service
- test TCP send response

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6844dd87ae208324872cde06a2ea23ee