### PR TITLE
Add basic FS commands for terminal

### DIFF
--- a/apps/index.ts
+++ b/apps/index.ts
@@ -4,12 +4,29 @@ export * from './nano';
 export * from './webBrowser';
 export * from './ping';
 export * from './desktop';
+export * from './ls';
+export * from './mkdir';
+export * from './rm';
+export * from './mv';
 
-import { NANO_SOURCE, BROWSER_SOURCE, PING_SOURCE, DESKTOP_SOURCE } from '../core/fs/bin';
+import {
+  NANO_SOURCE,
+  BROWSER_SOURCE,
+  PING_SOURCE,
+  DESKTOP_SOURCE,
+  LS_SOURCE,
+  MKDIR_SOURCE,
+  RM_SOURCE,
+  MV_SOURCE,
+} from '../core/fs/bin';
 
 export const BUNDLED_APPS = new Map<string, string>([
   ['nano', NANO_SOURCE],
   ['browser', BROWSER_SOURCE],
   ['ping', PING_SOURCE],
   ['desktop', DESKTOP_SOURCE],
+  ['ls', LS_SOURCE],
+  ['mkdir', MKDIR_SOURCE],
+  ['rm', RM_SOURCE],
+  ['mv', MV_SOURCE],
 ]);

--- a/apps/ls.ts
+++ b/apps/ls.ts
@@ -1,0 +1,1 @@
+export { LS_SOURCE } from '../core/fs/bin';

--- a/apps/mkdir.ts
+++ b/apps/mkdir.ts
@@ -1,0 +1,1 @@
+export { MKDIR_SOURCE } from '../core/fs/bin';

--- a/apps/mv.ts
+++ b/apps/mv.ts
@@ -1,0 +1,1 @@
+export { MV_SOURCE } from '../core/fs/bin';

--- a/apps/rm.ts
+++ b/apps/rm.ts
@@ -1,0 +1,1 @@
+export { RM_SOURCE } from '../core/fs/bin';

--- a/core/fs/bin.ts
+++ b/core/fs/bin.ts
@@ -187,6 +187,78 @@ export const DESKTOP_SOURCE = `
   }
 `;
 
+export const LS_SOURCE = `
+  async (syscall, argv) => {
+    const STDOUT_FD = 1;
+    const STDERR_FD = 2;
+    const encode = (s) => new TextEncoder().encode(s);
+    const path = argv[0] || '/';
+    try {
+      const entries = await syscall('readdir', path);
+      const names = entries.map(e => e.path.split('/').pop()).join('\n') + '\n';
+      await syscall('write', STDOUT_FD, encode(names));
+    } catch (e) {
+      await syscall('write', STDERR_FD, encode('ls: ' + e.message + '\n'));
+      return 1;
+    }
+    return 0;
+  }
+`;
+
+export const MKDIR_SOURCE = `
+  async (syscall, argv) => {
+    const STDERR_FD = 2;
+    const encode = (s) => new TextEncoder().encode(s);
+    if (argv.length === 0) {
+      await syscall('write', STDERR_FD, encode('mkdir: missing operand\n'));
+      return 1;
+    }
+    try {
+      await syscall('mkdir', argv[0], 0o755);
+    } catch (e) {
+      await syscall('write', STDERR_FD, encode('mkdir: ' + e.message + '\n'));
+      return 1;
+    }
+    return 0;
+  }
+`;
+
+export const RM_SOURCE = `
+  async (syscall, argv) => {
+    const STDERR_FD = 2;
+    const encode = (s) => new TextEncoder().encode(s);
+    if (argv.length === 0) {
+      await syscall('write', STDERR_FD, encode('rm: missing operand\n'));
+      return 1;
+    }
+    try {
+      await syscall('unlink', argv[0]);
+    } catch (e) {
+      await syscall('write', STDERR_FD, encode('rm: ' + e.message + '\n'));
+      return 1;
+    }
+    return 0;
+  }
+`;
+
+export const MV_SOURCE = `
+  async (syscall, argv) => {
+    const STDERR_FD = 2;
+    const encode = (s) => new TextEncoder().encode(s);
+    if (argv.length < 2) {
+      await syscall('write', STDERR_FD, encode('mv: missing operand\n'));
+      return 1;
+    }
+    try {
+      await syscall('rename', argv[0], argv[1]);
+    } catch (e) {
+      await syscall('write', STDERR_FD, encode('mv: ' + e.message + '\n'));
+      return 1;
+    }
+    return 0;
+  }
+`;
+
 
 export const CAT_MANIFEST = JSON.stringify({
   name: 'cat',
@@ -216,5 +288,25 @@ export const PING_MANIFEST = JSON.stringify({
 export const DESKTOP_MANIFEST = JSON.stringify({
   name: 'desktop',
   syscalls: ['open', 'read', 'write', 'close', 'spawn']
+});
+
+export const LS_MANIFEST = JSON.stringify({
+  name: 'ls',
+  syscalls: ['readdir', 'write']
+});
+
+export const MKDIR_MANIFEST = JSON.stringify({
+  name: 'mkdir',
+  syscalls: ['mkdir', 'write']
+});
+
+export const RM_MANIFEST = JSON.stringify({
+  name: 'rm',
+  syscalls: ['unlink', 'write']
+});
+
+export const MV_MANIFEST = JSON.stringify({
+  name: 'mv',
+  syscalls: ['rename', 'write']
 });
 

--- a/core/fs/index.test.ts
+++ b/core/fs/index.test.ts
@@ -37,3 +37,18 @@ function testUnmount() {
 testSnapshot();
 testUnmount();
 
+function testDirOps() {
+    const fs = new InMemoryFileSystem();
+    fs.createDirectory('/dir', 0o755);
+    fs.createFile('/dir/file.txt', 'data', 0o644);
+    const list = fs.listDirectory('/dir');
+    assert(list.some(n => n.path === '/dir/file.txt'), 'file listed');
+    fs.rename('/dir/file.txt', '/dir/renamed.txt');
+    assert(fs.getNode('/dir/renamed.txt'), 'rename works');
+    fs.remove('/dir/renamed.txt');
+    assert(!fs.getNode('/dir/renamed.txt'), 'file removed');
+    console.log('Directory ops test passed.');
+}
+
+testDirOps();
+

--- a/core/kernel.ts
+++ b/core/kernel.ts
@@ -278,6 +278,14 @@ export class Kernel {
           return this.syscall_udp_send(args[0], args[1]);
         case 'draw':
           return this.syscall_draw(args[0], args[1]);
+        case 'mkdir':
+          return this.syscall_mkdir(args[0], args[1]);
+        case 'readdir':
+          return this.syscall_readdir(args[0]);
+        case 'unlink':
+          return this.syscall_unlink(args[0]);
+        case 'rename':
+          return this.syscall_rename(args[0], args[1]);
         case 'snapshot':
           return this.snapshot();
         case 'save_snapshot':
@@ -428,6 +436,25 @@ export class Kernel {
     };
     eventBus.emit('draw', payload);
     return id;
+  }
+
+  private syscall_mkdir(path: string, perms: number): number {
+    this.fs.createDirectory(path, perms);
+    return 0;
+  }
+
+  private syscall_readdir(path: string): FileSystemNode[] {
+    return this.fs.listDirectory(path);
+  }
+
+  private syscall_unlink(path: string): number {
+    this.fs.remove(path);
+    return 0;
+  }
+
+  private syscall_rename(oldPath: string, newPath: string): number {
+    this.fs.rename(oldPath, newPath);
+    return 0;
   }
 
   public snapshot(): Snapshot {


### PR DESCRIPTION
## Summary
- implement `listDirectory`, `remove` and `rename` in the in-memory filesystem
- expose `mkdir`, `readdir`, `unlink` and `rename` syscalls
- add built-in programs `ls`, `mkdir`, `rm` and `mv`
- bundle new apps and their manifests
- test new filesystem operations

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6844eb930608832495c5f6a19dd978dd