### PR TITLE
Add mount syscall support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,18 +93,28 @@ while (true) {
 
 *Timeslice and quotas enforced by the Rust host (kill isolate on overrun).*
 
-### 3.3 Syscall Bus (minimal list)
+### 3.3 Syscall Bus
 
 | Call                      | Description       |
 | ------------------------- | ----------------- |
 | `open(path, flags)`       | returns fd        |
 | `read(fd, n)`             | Uint8Array        |
 | `write(fd, bytes)`        | count             |
+| `close(fd)`               | releases handle   |
 | `spawn(code, opts)`       | new PID           |
 | `listen(port, proto, cb)` | service daemon    |
 | `connect(ip, port)`       | socket handle     |
+| `tcp_send(sock, bytes)`   | TCP send          |
+| `udp_send(sock, bytes)`   | UDP send          |
 | `draw(htmlBlob, opts)`    | open GUI window   |
+| `mkdir(path, perms)`      | create directory  |
+| `readdir(path)`           | list directory    |
+| `unlink(path)`            | remove file       |
+| `rename(old, new)`        | move/rename file  |
+| `mount(img, path)`        | attach disk image |
+| `unmount(path)`           | detach disk image |
 | `snapshot()`              | returns JSON blob |
+| `save_snapshot()`         | persist snapshot  |
 
 ---
 

--- a/core/kernel.test.ts
+++ b/core/kernel.test.ts
@@ -14,6 +14,15 @@ async function run() {
   await startPromise;
   assert(ran, 'process should run');
   console.log('Kernel scheduler stop test passed.');
+
+  const img = new InMemoryFileSystem();
+  img.createFile('/foo.txt', 'bar', 0o644);
+  const snap = img.getSnapshot();
+  kernel['syscall_mount'](snap, '/mnt');
+  assert(kernel['fs'].getNode('/mnt/foo.txt'), 'file mounted');
+  kernel['syscall_unmount']('/mnt');
+  assert(!kernel['fs'].getNode('/mnt/foo.txt'), 'file unmounted');
+  console.log('Kernel mount/unmount test passed.');
 }
 
 run();

--- a/core/kernel.ts
+++ b/core/kernel.ts
@@ -1,7 +1,7 @@
 // Helios-OS Kernel
 // Implementation to follow based on the project roadmap. 
 
-import { InMemoryFileSystem, FileSystemNode } from './fs';
+import { InMemoryFileSystem, FileSystemNode, FileSystemSnapshot } from './fs';
 import {
   loadSnapshot,
   createPersistHook,
@@ -290,6 +290,10 @@ export class Kernel {
           return this.syscall_unlink(args[0]);
         case 'rename':
           return this.syscall_rename(args[0], args[1]);
+        case 'mount':
+          return this.syscall_mount(args[0], args[1]);
+        case 'unmount':
+          return this.syscall_unmount(args[0]);
         case 'snapshot':
           return this.snapshot();
         case 'save_snapshot':
@@ -458,6 +462,16 @@ export class Kernel {
 
   private syscall_rename(oldPath: string, newPath: string): number {
     this.fs.rename(oldPath, newPath);
+    return 0;
+  }
+
+  private syscall_mount(image: FileSystemSnapshot, path: string): number {
+    this.fs.mount(image, path);
+    return 0;
+  }
+
+  private syscall_unmount(path: string): number {
+    this.fs.unmount(path);
     return 0;
   }
 

--- a/docs/kernel.md
+++ b/docs/kernel.md
@@ -15,3 +15,28 @@ Processes are executed inside V8 isolates spawned by the host. Each process has 
 ### Snapshotting
 
 `core/fs/sqlite.ts` provides helpers to load and persist the entire kernel state. A snapshot is pure JSON that captures files, running processes and network connections. Loading a snapshot recreates the same environment deterministically.
+
+### Syscalls
+
+User programs interact with the kernel through an asynchronous syscall dispatcher. The table below lists all calls currently supported.
+
+| Call | Notes |
+| ---- | ----- |
+| `open(path, flags)` | open a file and return an fd |
+| `read(fd, n)` | read bytes from an fd |
+| `write(fd, bytes)` | write bytes to an fd |
+| `close(fd)` | close a file descriptor |
+| `spawn(code, opts)` | start a new process |
+| `listen(port, proto, cb)` | register a network service |
+| `connect(ip, port)` | obtain a socket handle |
+| `tcp_send(sock, bytes)` | send data over TCP |
+| `udp_send(sock, bytes)` | send data over UDP |
+| `draw(html, opts)` | open a GUI window |
+| `mkdir(path, perms)` | create a directory |
+| `readdir(path)` | list directory entries |
+| `unlink(path)` | remove a file or empty dir |
+| `rename(old, new)` | move or rename a node |
+| `mount(img, path)` | mount a disk image |
+| `unmount(path)` | unmount a disk image |
+| `snapshot()` | return the full machine state |
+| `save_snapshot()` | persist state to disk |


### PR DESCRIPTION
## Summary
- add `mount` and `unmount` syscalls to the kernel
- document the full syscall list in README and kernel guide
- test mounting behaviour in the kernel test suite

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6844efad3d1883249653fcecfa4403ce