### PR TITLE
Improve window server behaviour

### DIFF
--- a/core/eventBus.ts
+++ b/core/eventBus.ts
@@ -8,6 +8,7 @@ export interface DrawPayload {
 
 export interface EventMap {
   draw: DrawPayload;
+  'desktop.createWindow': DrawPayload;
 }
 
 export type Handler<T = any> = (payload: T) => void;

--- a/core/kernel.ts
+++ b/core/kernel.ts
@@ -465,7 +465,7 @@ export class Kernel {
       html: new TextDecoder().decode(html),
       opts,
     };
-    eventBus.emit('draw', payload);
+    eventBus.emit('desktop.createWindow', payload);
     return id;
   }
 

--- a/ui/components/Window.tsx
+++ b/ui/components/Window.tsx
@@ -4,21 +4,37 @@ import { ResizableBox } from 'react-resizable';
 import './Window.css';
 
 interface WindowProps {
+  id: number;
   title: string;
   initialPosition?: { x: number; y: number };
   initialSize?: { width: number; height: number };
   onResize?: (size: { width: number, height: number }) => void;
+  onFocus?: (id: number) => void;
+  zIndex?: number;
   children: React.ReactNode;
 }
 
 export const Window: React.FC<WindowProps> = ({
+  id,
   title,
   initialPosition = { x: 50, y: 50 },
   initialSize = { width: 720, height: 500 },
   onResize,
+  onFocus,
+  zIndex,
   children,
 }) => {
   const nodeRef = useRef(null);
+  const content =
+    typeof children === 'string' ? (
+      <iframe
+        srcDoc={children as string}
+        sandbox="allow-scripts"
+        style={{ width: '100%', height: '100%', border: 'none' }}
+      />
+    ) : (
+      children
+    );
 
   return (
     <Draggable
@@ -27,7 +43,11 @@ export const Window: React.FC<WindowProps> = ({
       bounds="parent"
       nodeRef={nodeRef}
     >
-      <div ref={nodeRef} style={{ position: 'absolute' }}>
+      <div
+        ref={nodeRef}
+        style={{ position: 'absolute', zIndex }}
+        onMouseDown={() => onFocus?.(id)}
+      >
         <ResizableBox
           width={initialSize.width}
           height={initialSize.height}
@@ -44,11 +64,9 @@ export const Window: React.FC<WindowProps> = ({
             </div>
             <div className="window-title">{title}</div>
           </div>
-          <div className="window-content">
-            {children}
-          </div>
+          <div className="window-content">{content}</div>
         </ResizableBox>
       </div>
     </Draggable>
   );
-}; 
+};

--- a/ui/components/WindowManager.tsx
+++ b/ui/components/WindowManager.tsx
@@ -34,6 +34,15 @@ export const WindowManager = forwardRef<WindowManagerHandles, WindowManagerProps
     setWindows(w => [...w, state]);
   };
 
+  const focusWindow = (id: number) => {
+    setWindows(w => {
+      const idx = w.findIndex(win => win.id === id);
+      if (idx === -1 || idx === w.length - 1) return w;
+      const win = w[idx];
+      return [...w.slice(0, idx), ...w.slice(idx + 1), win];
+    });
+  };
+
   const closeWindow = (id: number) => {
     setWindows(w => w.filter(win => win.id !== id));
   };
@@ -42,19 +51,18 @@ export const WindowManager = forwardRef<WindowManagerHandles, WindowManagerProps
 
   return (
     <div className="window-manager-container" style={{ position: 'relative', width: '100vw', height: '100vh' }}>
-      {windows.map(win => (
+      {windows.map((win, index) => (
         <Window
           key={win.id}
+          id={win.id}
           title={win.title ?? `Window ${win.id}`}
           initialPosition={win.position}
           initialSize={win.size}
+          zIndex={index + 1}
           onResize={win.id === 0 ? onResize : undefined}
+          onFocus={focusWindow}
         >
-          {typeof win.content === 'string' ? (
-            <div dangerouslySetInnerHTML={{ __html: win.content as string }} />
-          ) : (
-            win.content
-          )}
+          {win.content}
         </Window>
       ))}
     </div>

--- a/ui/index.tsx
+++ b/ui/index.tsx
@@ -88,8 +88,8 @@ const App = () => {
             });
         };
 
-        eventBus.on('draw', handler);
-        return () => eventBus.off('draw', handler);
+        eventBus.on('desktop.createWindow', handler);
+        return () => eventBus.off('desktop.createWindow', handler);
     }, []);
 
     const handleResize = useCallback(() => {


### PR DESCRIPTION
## Summary
- emit `desktop.createWindow` event from the kernel
- update event bus type for new event
- listen for the new event in the React UI
- sandbox window content in `<iframe>` elements
- allow focusing windows with z-order handling

## Testing
- `pnpm i`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6845f8d10f408324af0b00c0ed63d560