### PR TITLE
Enable closing windows via mouse

### DIFF
--- a/ui/components/Window.tsx
+++ b/ui/components/Window.tsx
@@ -10,6 +10,7 @@ interface WindowProps {
   initialSize?: { width: number; height: number };
   onResize?: (size: { width: number, height: number }) => void;
   onFocus?: (id: number) => void;
+  onClose?: (id: number) => void;
   zIndex?: number;
   children: React.ReactNode;
 }
@@ -21,6 +22,7 @@ export const Window: React.FC<WindowProps> = ({
   initialSize = { width: 720, height: 500 },
   onResize,
   onFocus,
+  onClose,
   zIndex,
   children,
 }) => {
@@ -58,7 +60,7 @@ export const Window: React.FC<WindowProps> = ({
         >
           <div className="window-title-bar">
             <div className="window-buttons">
-              <div className="window-button" />
+              <div className="window-button" onClick={() => onClose?.(id)} />
               <div className="window-button" />
               <div className="window-button" />
             </div>

--- a/ui/components/WindowManager.tsx
+++ b/ui/components/WindowManager.tsx
@@ -61,6 +61,7 @@ export const WindowManager = forwardRef<WindowManagerHandles, WindowManagerProps
           zIndex={index + 1}
           onResize={win.id === 0 ? onResize : undefined}
           onFocus={focusWindow}
+          onClose={closeWindow}
         >
           {win.content}
         </Window>


### PR DESCRIPTION
## Summary
- allow the `Window` component to signal close events
- wire the close button in the window chrome
- pass the close handler from `WindowManager`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6845fba754e4832496ac857343ae78e8