### PR TITLE
Fix router and open syscall handling

### DIFF
--- a/core/kernel.test.ts
+++ b/core/kernel.test.ts
@@ -23,6 +23,16 @@ async function run() {
   kernel['syscall_unmount']('/mnt');
   assert(!kernel['state'].fs.getNode('/mnt/foo.txt'), 'file unmounted');
   console.log('Kernel mount/unmount test passed.');
+
+  const pid = kernel['createProcess']();
+  const pcb = kernel['state'].processes.get(pid);
+  try {
+    kernel['syscall_open'](pcb, '/', 'r');
+    assert.fail('opening directory should throw');
+  } catch (e: any) {
+    assert(e.message.includes('EISDIR'), 'EISDIR error expected');
+    console.log('Kernel open directory test passed.');
+  }
 }
 
 run();

--- a/core/kernel.ts
+++ b/core/kernel.ts
@@ -334,6 +334,8 @@ export class Kernel {
       } else {
         throw new Error(`ENOENT: no such file or directory, open '${path}'`);
       }
+    } else if (node.kind === 'dir') {
+      throw new Error(`EISDIR: illegal operation on a directory, open '${path}'`);
     }
 
     const needsRead = flags.includes('r');

--- a/core/net/index.test.ts
+++ b/core/net/index.test.ts
@@ -51,7 +51,7 @@ function testRouter() {
     const router = new Router();
     const nic1 = new NIC('1', 'AA');
     const nic2 = new NIC('2', 'BB');
-    router.addRoute('192.168.1./24', nic2);
+    router.addRoute('192.168.1.0/24', nic2);
     const frame = { src: '10.0.0.1', dst: '192.168.1.5', payload: new Uint8Array([3]) };
     router.forward(frame);
     assert(nic2.rx.length === 1 && nic2.rx[0] === frame, 'router forwards to correct NIC');

--- a/core/net/router.ts
+++ b/core/net/router.ts
@@ -1,20 +1,33 @@
 import { NIC, Frame } from './nic';
 
 export interface Route {
-  network: string; // e.g., '127.0.0.0/8'
+  net: number;
+  mask: number;
   nic: NIC;
+}
+
+function ipToInt(ip: string): number {
+  return ip
+    .split('.')
+    .map(o => parseInt(o, 10))
+    .reduce((acc, octet) => (acc << 8) | (octet & 0xff), 0);
 }
 
 export class Router {
   private routes: Route[] = [];
 
   addRoute(network: string, nic: NIC) {
-    this.routes.push({ network, nic });
+    const [ipStr, maskStr] = network.split('/');
+    const maskBits = parseInt(maskStr, 10);
+    const mask = maskBits === 0 ? 0 : 0xffffffff << (32 - maskBits);
+    const net = ipToInt(ipStr) & mask;
+    this.routes.push({ net, mask, nic });
   }
 
   forward(frame: Frame) {
+    const dst = ipToInt(frame.dst);
     for (const r of this.routes) {
-      if (frame.dst.startsWith(r.network.split('/')[0])) {
+      if ((dst & r.mask) === r.net) {
         r.nic.rx.push(frame);
         return;
       }


### PR DESCRIPTION
## Summary
- improve IP routing logic by parsing CIDR routes
- validate directory access in `syscall_open`
- update tests for router and new open validation

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6845fd30430483249d796ebf9725c1b0