### PR TITLE
Add init and login programs

### DIFF
--- a/apps/index.ts
+++ b/apps/index.ts
@@ -9,6 +9,8 @@ export * from './mkdir';
 export * from './rm';
 export * from './mv';
 export * from './ps';
+export * from './init';
+export * from './login';
 
 import {
   NANO_SOURCE,
@@ -20,6 +22,8 @@ import {
   RM_SOURCE,
   MV_SOURCE,
   PS_SOURCE,
+  INIT_SOURCE,
+  LOGIN_SOURCE,
 } from '../core/fs/bin';
 
 export const BUNDLED_APPS = new Map<string, string>([
@@ -32,4 +36,6 @@ export const BUNDLED_APPS = new Map<string, string>([
   ['rm', RM_SOURCE],
   ['mv', MV_SOURCE],
   ['ps', PS_SOURCE],
+  ['init', INIT_SOURCE],
+  ['login', LOGIN_SOURCE],
 ]);

--- a/apps/init.ts
+++ b/apps/init.ts
@@ -1,0 +1,2 @@
+export { INIT_SOURCE } from '../core/fs/bin';
+

--- a/apps/login.ts
+++ b/apps/login.ts
@@ -1,0 +1,2 @@
+export { LOGIN_SOURCE } from '../core/fs/bin';
+

--- a/core/fs/index.ts
+++ b/core/fs/index.ts
@@ -6,6 +6,8 @@ import {
   PING_SOURCE,
   DESKTOP_SOURCE,
   PS_SOURCE,
+  INIT_SOURCE,
+  LOGIN_SOURCE,
   CAT_MANIFEST,
   ECHO_MANIFEST,
   NANO_MANIFEST,
@@ -13,6 +15,8 @@ import {
   PING_MANIFEST,
   DESKTOP_MANIFEST,
   PS_MANIFEST,
+  INIT_MANIFEST,
+  LOGIN_MANIFEST,
 } from './bin';
 import { createPersistHook } from './sqlite';
 
@@ -99,6 +103,12 @@ export class InMemoryFileSystem {
     this.createFile('/bin/desktop.manifest.json', DESKTOP_MANIFEST, 0o644);
     this.createFile('/bin/ps', PS_SOURCE, 0o755);
     this.createFile('/bin/ps.manifest.json', PS_MANIFEST, 0o644);
+
+    this.createDirectory('/sbin', 0o755);
+    this.createFile('/sbin/init', INIT_SOURCE, 0o755);
+    this.createFile('/sbin/init.manifest.json', INIT_MANIFEST, 0o644);
+    this.createFile('/bin/login', LOGIN_SOURCE, 0o755);
+    this.createFile('/bin/login.manifest.json', LOGIN_MANIFEST, 0o644);
 
     const bundled = (globalThis as any).BUNDLED_DISK_IMAGES as
       | Array<{ image: FileSystemSnapshot; path: string }>


### PR DESCRIPTION
## Summary
- implement `/sbin/init` that launches login
- implement `/bin/login` which reads from `/dev/tty0` and runs bash
- bundle new programs in the filesystem
- export init and login through app index

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6846ee649d888324bd9d54266e459788