### PR TITLE
Update docs for pnpm build:release

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Kernel denies undeclared syscalls.
 1. `pnpm i` – installs deps, including `@xterm/*` (new scoped pkgs). ([github.com][7])
 2. `tsconfig.json` defines repo-wide TypeScript options (`target`/`module` set to `esnext`, `jsx` to `react`).
 3. `pnpm dev` – starts Tauri dev server; hot-reload UI & kernel TS.
-4. `cargo tauri build --release` – cross-build Win/macOS/Linux/ARM.
+4. `pnpm build:release` – cross-build Win/macOS/Linux/ARM.
 5. `helios snap path/to/out.helios` – CLI packs snapshot for Steam Workshop.
 6. **Modders:** drop TS file in `apps/`, run `makepkg`, publish to own apt repo.
 

--- a/docs/boot_performance.md
+++ b/docs/boot_performance.md
@@ -4,7 +4,13 @@ To measure Helios-OS boot duration:
 
 1. Open `ui/index.tsx` and ensure `bootStartRef` records the timestamp before `Kernel.create()`.
 2. When the kernel emits `boot.shellReady`, subtract the timestamp from the current time and log the value.
-3. Run the UI and check the browser console for `Boot completed in X ms`.
+3. Build the project in release mode and run the host:
+
+    ```sh
+    pnpm build:release
+    ```
+
+   Then check the console for `Boot completed in X ms`.
 
 This method captures the time from kernel creation until the interactive shell is ready after login.
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -12,9 +12,18 @@ This project uses `pnpm` for managing Node dependencies and scripts.
 
     ```sh
     pnpm dev
+
+    # Compile the Rust host with optimizations
+    pnpm dev:release
     ```
 
-3. Run the test suite before committing:
+3. Build a release bundle for distribution:
+
+    ```sh
+    pnpm build:release
+    ```
+
+4. Run the test suite before committing:
 
     ```sh
     pnpm test

--- a/host/tauri.conf.json
+++ b/host/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "../../node_modules/@tauri-apps/cli/schema.json",
   "build": {
     "devPath": "http://localhost:1420/ui/index.html",
-    "distDir": "../../dist",
+    "distDir": "../dist",
     "withGlobalTauri": true
   },
   "package": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "concurrently \"pnpm:dev:ui\" \"pnpm:dev:host\"",
     "dev:ui": "esbuild ui/index.tsx --bundle --outfile=dist/bundle.js --tsconfig=tsconfig.json --servedir=. --watch --serve=:1420",
     "dev:host": "sleep 5 && cd host && tauri dev",
-    "build": "esbuild ui/index.tsx --bundle --outfile=dist/bundle.js --target=esnext --platform=browser --tsconfig=tsconfig.json",
+    "dev:host:release": "sleep 5 && cd host && tauri dev --release",
+    "dev:release": "concurrently \"pnpm:dev:ui\" \"pnpm:dev:host:release\"",
+    "build": "esbuild ui/index.tsx --bundle --outfile=dist/bundle.js --target=esnext --platform=browser --tsconfig=tsconfig.json && cp ui/index.html dist/index.html",
     "build:release": "pnpm build && cd host && tauri build",
     "helios": "tsx tools/helios.ts",
     "test": "esbuild core/fs/index.test.ts --bundle --platform=node --format=cjs --tsconfig=tsconfig.json --outfile=core/fs/index.test.js && node core/fs/index.test.js && rm core/fs/index.test.js && esbuild core/kernel.test.ts --bundle --platform=node --format=cjs --tsconfig=tsconfig.json --outfile=core/kernel.test.js && node core/kernel.test.js && rm core/kernel.test.js && esbuild core/net/index.test.ts --bundle --platform=node --format=cjs --tsconfig=tsconfig.json --outfile=core/net/index.test.js && node core/net/index.test.js && rm core/net/index.test.js"


### PR DESCRIPTION
## Summary
- update developer workflow and boot measurement docs
- reference `pnpm build:release` in root README
- fix Tauri config path for release builds
- add release variants of dev scripts and copy `index.html` during build

## Testing
- `pnpm build` (fails: Error unable to find web assets) -> fixed
- `pnpm build:release` (fails: custom-protocol feature missing)
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6846f59018d88324ade08e6c57419130