### PR TITLE
Add reboot syscall and command

### DIFF
--- a/core/eventBus.ts
+++ b/core/eventBus.ts
@@ -10,6 +10,7 @@ export interface EventMap {
   draw: DrawPayload;
   'desktop.createWindow': DrawPayload;
   'boot.shellReady': { pid: number };
+  'system.reboot': {};
 }
 
 export type Handler<T = any> = (payload: T) => void;

--- a/core/fs/bin.ts
+++ b/core/fs/bin.ts
@@ -435,3 +435,15 @@ export const INIT_MANIFEST = JSON.stringify({
   syscalls: ['open', 'read', 'write', 'close', 'spawn']
 });
 
+export const REBOOT_SOURCE = `
+  async (syscall) => {
+    await syscall('reboot');
+    return 0;
+  }
+`;
+
+export const REBOOT_MANIFEST = JSON.stringify({
+  name: 'reboot',
+  syscalls: ['reboot']
+});
+

--- a/core/fs/index.ts
+++ b/core/fs/index.ts
@@ -9,6 +9,7 @@ import {
   INIT_SOURCE,
   LOGIN_SOURCE,
   BASH_SOURCE,
+  REBOOT_SOURCE,
   CAT_MANIFEST,
   ECHO_MANIFEST,
   NANO_MANIFEST,
@@ -19,6 +20,7 @@ import {
   INIT_MANIFEST,
   LOGIN_MANIFEST,
   BASH_MANIFEST,
+  REBOOT_MANIFEST,
 } from './bin';
 import { createPersistHook } from './sqlite';
 
@@ -109,6 +111,8 @@ export class InMemoryFileSystem {
     this.createDirectory('/sbin', 0o755);
     this.createFile('/sbin/init', INIT_SOURCE, 0o755);
     this.createFile('/sbin/init.manifest.json', INIT_MANIFEST, 0o644);
+    this.createFile('/sbin/reboot', REBOOT_SOURCE, 0o755);
+    this.createFile('/sbin/reboot.manifest.json', REBOOT_MANIFEST, 0o644);
     this.createFile('/bin/login', LOGIN_SOURCE, 0o755);
     this.createFile('/bin/login.manifest.json', LOGIN_MANIFEST, 0o644);
     this.createFile('/bin/bash', BASH_SOURCE, 0o755);

--- a/core/kernel.ts
+++ b/core/kernel.ts
@@ -349,6 +349,8 @@ export class Kernel {
           return 0;
         case 'ps':
           return this.syscall_ps();
+        case 'reboot':
+          return this.reboot();
         default:
           throw new Error(`Unknown syscall: ${call}`);
       }
@@ -617,5 +619,10 @@ export class Kernel {
   public stop(): void {
     persistKernelSnapshot(this.snapshot());
     this.running = false;
+  }
+
+  public reboot(): void {
+    this.stop();
+    eventBus.emit('system.reboot', {});
   }
 }


### PR DESCRIPTION
## Summary
- emit a `system.reboot` event when the kernel reboots
- expose `reboot` via syscall dispatcher
- provide REBOOT binary and manifest
- install `/sbin/reboot` in the default FS
- update event bus typings for the reboot event

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6846f8eb144c8324877ea4769b62b7af