### PR TITLE
Document reboot persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ Kernel denies undeclared syscalls.
   * Server keeps per-machine block-diffs, per-ISP ledger, global DNS zone.
   * Delta sync every 3 s; SHA-1 epoch hash ensures determinism.
   * Rollback: operator replaces diff chain; clients auto-replay.
+* `reboot` saves the current snapshot and reloads it on next boot so services
+  and open windows persist.
 
 ---
 

--- a/docs/kernel.md
+++ b/docs/kernel.md
@@ -40,3 +40,10 @@ User programs interact with the kernel through an asynchronous syscall dispatche
 | `unmount(path)` | unmount a disk image |
 | `snapshot()` | return the full machine state |
 | `save_snapshot()` | persist state to disk |
+
+### Reboot and restore
+
+The `/sbin/reboot` command calls `kernel.reboot()`. This persists the current
+snapshot via `save_snapshot()` and stops the scheduler. On the next boot
+`Kernel.create()` loads that snapshot, recreating services and open windows so
+the desktop resumes exactly where it left off.


### PR DESCRIPTION
## Summary
- explain in README how `reboot` writes a snapshot and restores it
- add a section in docs/kernel.md on reboot behaviour

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6847010014c4832485e5836d05385f7b