### PR TITLE
Add named snapshot database and API

### DIFF
--- a/core/fs/sqlite.ts
+++ b/core/fs/sqlite.ts
@@ -41,3 +41,23 @@ export async function persistKernelSnapshot(snapshot: any) {
     // ignore
   }
 }
+
+export async function saveNamedSnapshot(name: string, snapshot: any) {
+    try {
+        await invoke('save_named_snapshot', {
+            name,
+            json: JSON.stringify(snapshot),
+        });
+    } catch {
+        // ignore
+    }
+}
+
+export async function loadNamedSnapshot(name: string): Promise<any | null> {
+    try {
+        const result = await invoke<any>('load_named_snapshot', { name });
+        return result as any;
+    } catch {
+        return null;
+    }
+}

--- a/host/src/db.rs
+++ b/host/src/db.rs
@@ -38,6 +38,14 @@ pub fn snapshot() -> Result<Connection, String> {
         eprintln!("Database Error: {}", msg);
         return Err(msg);
     }
+    if let Err(e) = conn.execute(
+        "CREATE TABLE IF NOT EXISTS snapshots (name TEXT PRIMARY KEY, json TEXT)",
+        [],
+    ) {
+        let msg = e.to_string();
+        eprintln!("Database Error: {}", msg);
+        return Err(msg);
+    }
     Ok(conn)
 }
 


### PR DESCRIPTION
## Summary
- extend snapshot DB schema with `snapshots` table
- add `save_named_snapshot` and `load_named_snapshot` Tauri commands
- expose the new commands via helpers in `core/fs/sqlite.ts`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684727a997888324bb1aa8c8fc1bfe13