### PR TITLE
Add named snapshot APIs to kernel

### DIFF
--- a/core/kernel.ts
+++ b/core/kernel.ts
@@ -8,6 +8,8 @@ import {
   createPersistHook,
   loadKernelSnapshot,
   persistKernelSnapshot,
+  saveNamedSnapshot,
+  loadNamedSnapshot,
 } from './fs/sqlite';
 import { invoke } from '@tauri-apps/api/tauri';
 import { listen } from '@tauri-apps/api/event';
@@ -386,6 +388,17 @@ export class Kernel {
         case 'save_snapshot':
           persistKernelSnapshot(this.snapshot());
           return 0;
+        case 'save_snapshot_named':
+          await saveNamedSnapshot(args[0], this.snapshot());
+          return 0;
+        case 'load_snapshot_named': {
+          const snap = await loadNamedSnapshot(args[0]);
+          if (!snap) return -1;
+          this.running = false;
+          persistKernelSnapshot(snap);
+          eventBus.emit('system.reboot', {});
+          return 0;
+        }
         case 'ps':
           return this.syscall_ps();
         case 'reboot':

--- a/docs/kernel.md
+++ b/docs/kernel.md
@@ -40,10 +40,14 @@ User programs interact with the kernel through an asynchronous syscall dispatche
 | `unmount(path)` | unmount a disk image |
 | `snapshot()` | return the full machine state |
 | `save_snapshot()` | persist state to disk |
+| `save_snapshot_named(name)` | persist to named slot |
+| `load_snapshot_named(name)` | load slot & reboot |
 
 ### Reboot and restore
 
 The `/sbin/reboot` command calls `kernel.reboot()`. This persists the current
 snapshot via `save_snapshot()` and stops the scheduler. On the next boot
 `Kernel.create()` loads that snapshot, recreating services and open windows so
-the desktop resumes exactly where it left off.
+the desktop resumes exactly where it left off. Calling
+`load_snapshot_named(name)` loads the requested snapshot, saves it as the active
+one and reboots automatically so the restored state becomes live.


### PR DESCRIPTION
## Summary
- dispatch `save_snapshot_named` and `load_snapshot_named`
- handle `load_snapshot_named` by persisting the loaded snapshot and rebooting
- document new syscalls in `docs/kernel.md`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6847289f614083248e9cbf3821fe5607