### PR TITLE
Add snapshot cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Kernel denies undeclared syscalls.
   * Rollback: operator replaces diff chain; clients auto-replay.
 * `reboot` saves the current snapshot and reloads it on next boot so services
   and open windows persist.
+* `snapshot save <name>` stores the state and `snapshot load <name>` restores it.
 
 ---
 

--- a/apps/index.ts
+++ b/apps/index.ts
@@ -12,6 +12,7 @@ export * from './ps';
 export * from './init';
 export * from './login';
 export * from './bash';
+export * from './snapshot';
 
 import {
   NANO_SOURCE,
@@ -26,6 +27,7 @@ import {
   INIT_SOURCE,
   LOGIN_SOURCE,
   BASH_SOURCE,
+  SNAPSHOT_SOURCE,
 } from '../core/fs/bin';
 
 export const BUNDLED_APPS = new Map<string, string>([
@@ -41,4 +43,6 @@ export const BUNDLED_APPS = new Map<string, string>([
   ['init', INIT_SOURCE],
   ['login', LOGIN_SOURCE],
   ['bash', BASH_SOURCE],
+  ['snapshot', SNAPSHOT_SOURCE],
 ]);
+

--- a/apps/snapshot.ts
+++ b/apps/snapshot.ts
@@ -1,0 +1,2 @@
+export { SNAPSHOT_SOURCE } from '../core/fs/bin';
+

--- a/core/fs/bin.ts
+++ b/core/fs/bin.ts
@@ -447,3 +447,38 @@ export const REBOOT_MANIFEST = JSON.stringify({
   syscalls: ['reboot']
 });
 
+export const SNAPSHOT_SOURCE = `
+  async (syscall, argv) => {
+    const STDERR_FD = 2;
+    const encode = (s) => new TextEncoder().encode(s);
+
+    if (argv.length < 2) {
+      await syscall('write', STDERR_FD, encode('usage: snapshot <save|load> <name>\n'));
+      return 1;
+    }
+
+    const action = argv[0];
+    const name = argv[1];
+
+    if (action === 'save') {
+      const snap = await syscall('snapshot');
+      await syscall('save_snapshot_named', name, snap);
+      return 0;
+    }
+
+    if (action === 'load') {
+      await syscall('load_snapshot_named', name);
+      await syscall('reboot');
+      return 0;
+    }
+
+    await syscall('write', STDERR_FD, encode('snapshot: unknown action\n'));
+    return 1;
+  }
+`;
+
+export const SNAPSHOT_MANIFEST = JSON.stringify({
+  name: 'snapshot',
+  syscalls: ['snapshot', 'save_snapshot_named', 'load_snapshot_named', 'reboot', 'write']
+});
+

--- a/core/fs/index.ts
+++ b/core/fs/index.ts
@@ -10,6 +10,7 @@ import {
   LOGIN_SOURCE,
   BASH_SOURCE,
   REBOOT_SOURCE,
+  SNAPSHOT_SOURCE,
   CAT_MANIFEST,
   ECHO_MANIFEST,
   NANO_MANIFEST,
@@ -21,6 +22,7 @@ import {
   LOGIN_MANIFEST,
   BASH_MANIFEST,
   REBOOT_MANIFEST,
+  SNAPSHOT_MANIFEST,
 } from './bin';
 import { createPersistHook } from './sqlite';
 
@@ -113,6 +115,8 @@ export class InMemoryFileSystem {
     this.createFile('/sbin/init.manifest.json', INIT_MANIFEST, 0o644);
     this.createFile('/sbin/reboot', REBOOT_SOURCE, 0o755);
     this.createFile('/sbin/reboot.manifest.json', REBOOT_MANIFEST, 0o644);
+    this.createFile('/sbin/snapshot', SNAPSHOT_SOURCE, 0o755);
+    this.createFile('/sbin/snapshot.manifest.json', SNAPSHOT_MANIFEST, 0o644);
     this.createFile('/bin/login', LOGIN_SOURCE, 0o755);
     this.createFile('/bin/login.manifest.json', LOGIN_MANIFEST, 0o644);
     this.createFile('/bin/bash', BASH_SOURCE, 0o755);

--- a/docs/kernel.md
+++ b/docs/kernel.md
@@ -51,3 +51,4 @@ snapshot via `save_snapshot()` and stops the scheduler. On the next boot
 the desktop resumes exactly where it left off. Calling
 `load_snapshot_named(name)` loads the requested snapshot, saves it as the active
 one and reboots automatically so the restored state becomes live.
+The `/sbin/snapshot` utility provides `snapshot save <name>` and `snapshot load <name>` for manual state management.


### PR DESCRIPTION
## Summary
- implement `SNAPSHOT_SOURCE` with save/load actions
- register snapshot binary in filesystem
- expose new utility from `apps` and bundle it
- document snapshot command in README and kernel docs

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684729bf34b08324803f9ea9da88d76c