### PR TITLE
Add snapshot determinism test

### DIFF
--- a/core/snapshot.test.ts
+++ b/core/snapshot.test.ts
@@ -1,0 +1,21 @@
+import assert from 'assert';
+import { createHash } from 'node:crypto';
+import { Kernel } from './kernel';
+import { InMemoryFileSystem } from './fs';
+
+function checksum(obj: any): string {
+    return createHash('sha256').update(JSON.stringify(obj)).digest('hex');
+}
+
+async function run() {
+    const kernel: any = new (Kernel as any)(new InMemoryFileSystem());
+    const snap1 = kernel.snapshot();
+    const restored1: any = await (Kernel as any).restore(snap1);
+    const snap2 = restored1.snapshot();
+    const restored2: any = await (Kernel as any).restore(snap2);
+    const snap3 = restored2.snapshot();
+    assert.strictEqual(checksum(snap2), checksum(snap3), 'snapshot checksums must match');
+    console.log('Snapshot deterministic load test passed.');
+}
+
+run();

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "esbuild ui/index.tsx --bundle --outfile=dist/bundle.js --target=esnext --platform=browser --tsconfig=tsconfig.json && cp ui/index.html dist/index.html",
     "build:release": "pnpm build && cd host && tauri build",
     "helios": "tsx tools/helios.ts",
-    "test": "esbuild core/fs/index.test.ts --bundle --platform=node --format=cjs --tsconfig=tsconfig.json --outfile=core/fs/index.test.js && node core/fs/index.test.js && rm core/fs/index.test.js && esbuild core/kernel.test.ts --bundle --platform=node --format=cjs --tsconfig=tsconfig.json --outfile=core/kernel.test.js && node core/kernel.test.js && rm core/kernel.test.js && esbuild core/net/index.test.ts --bundle --platform=node --format=cjs --tsconfig=tsconfig.json --outfile=core/net/index.test.js && node core/net/index.test.js && rm core/net/index.test.js"
+    "test": "esbuild core/fs/index.test.ts --bundle --platform=node --format=cjs --tsconfig=tsconfig.json --outfile=core/fs/index.test.js && node core/fs/index.test.js && rm core/fs/index.test.js && esbuild core/kernel.test.ts --bundle --platform=node --format=cjs --tsconfig=tsconfig.json --outfile=core/kernel.test.js && node core/kernel.test.js && rm core/kernel.test.js && esbuild core/net/index.test.ts --bundle --platform=node --format=cjs --tsconfig=tsconfig.json --outfile=core/net/index.test.js && node core/net/index.test.js && rm core/net/index.test.js && esbuild core/snapshot.test.ts --bundle --platform=node --format=cjs --tsconfig=tsconfig.json --outfile=core/snapshot.test.js && node core/snapshot.test.js && rm core/snapshot.test.js"
     },
   "dependencies": {
     "@pablo-lion/xterm-react": "^1.1.2",


### PR DESCRIPTION
## Summary
- ensure kernel snapshot restore results are deterministic
- run tests in snapshot.test

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68472ba0481c8324b204057db35504ee