### PR TITLE
Add async filesystem wrappers

### DIFF
--- a/core/fs/async.ts
+++ b/core/fs/async.ts
@@ -1,0 +1,13 @@
+import type { FileSystemNode, FileSystemSnapshot, Permissions } from './index';
+
+export interface AsyncFileSystem {
+    open(path: string, flags?: string): Promise<FileSystemNode | undefined>;
+    read(path: string): Promise<Uint8Array>;
+    write(path: string, data: Uint8Array): Promise<void>;
+    mkdir(path: string, permissions: Permissions): Promise<void>;
+    readdir(path: string): Promise<FileSystemNode[]>;
+    unlink(path: string): Promise<void>;
+    rename(oldPath: string, newPath: string): Promise<void>;
+    mount(image: FileSystemSnapshot, path: string): Promise<void>;
+    unmount(path: string): Promise<void>;
+}

--- a/core/fs/pure.ts
+++ b/core/fs/pure.ts
@@ -1,7 +1,7 @@
-import { InMemoryFileSystem, FileSystemNode } from './index';
+import { InMemoryFileSystem, FileSystemNode, FileSystem as DefaultFileSystem } from './index';
 import { createPersistHook } from './sqlite';
 
-export type FileSystem = InMemoryFileSystem;
+export type FileSystem = DefaultFileSystem;
 export type FileNode = FileSystemNode & { kind: 'file'; data: Uint8Array };
 
 export function fsLookup(fs: FileSystem, path: string): FileSystemNode | undefined {

--- a/core/fs/sqlite.ts
+++ b/core/fs/sqlite.ts
@@ -19,8 +19,8 @@ export async function persistSnapshot(snapshot: FileSystemSnapshot) {
 }
 
 export function createPersistHook(): PersistHook {
-  return (snapshot: FileSystemSnapshot) => {
-    persistSnapshot(snapshot);
+  return async (snapshot: FileSystemSnapshot) => {
+    await persistSnapshot(snapshot);
   };
 }
 


### PR DESCRIPTION
## Summary
- define `AsyncFileSystem` interface
- implement async methods on `InMemoryFileSystem`
- expose a `FileSystem` type that meets both sync and async APIs
- await `persistSnapshot` in SQLite hook

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68473043638883249d86875fca479564