### PR TITLE
Use async FS loader in Kernel

### DIFF
--- a/core/fs/index.ts
+++ b/core/fs/index.ts
@@ -24,7 +24,7 @@ import {
   REBOOT_MANIFEST,
   SNAPSHOT_MANIFEST,
 } from './bin';
-import { createPersistHook } from './sqlite';
+import { createPersistHook, loadSnapshot } from './sqlite';
 import type { AsyncFileSystem } from './async';
 
 /**
@@ -523,3 +523,9 @@ export class InMemoryFileSystem implements AsyncFileSystem {
 }
 
 export type FileSystem = InMemoryFileSystem & AsyncFileSystem;
+
+export async function loadFileSystem(): Promise<FileSystem | null> {
+  const snapshot = await loadSnapshot();
+  if (!snapshot) return null;
+  return new InMemoryFileSystem(snapshot, createPersistHook());
+}

--- a/core/kernel.ts
+++ b/core/kernel.ts
@@ -1,10 +1,9 @@
 // Helios-OS Kernel
 // Implementation to follow based on the project roadmap. 
 
-import { InMemoryFileSystem, FileSystemNode, FileSystemSnapshot } from './fs';
+import { InMemoryFileSystem, FileSystemNode, FileSystemSnapshot, loadFileSystem } from './fs';
 import { bootstrapFileSystem } from './fs/pure';
 import {
-  loadSnapshot,
   createPersistHook,
   loadKernelSnapshot,
   persistKernelSnapshot,
@@ -134,10 +133,7 @@ export class Kernel {
       return Kernel.restore(full as Snapshot);
     }
 
-    const snapshot = await loadSnapshot();
-    const fs = snapshot
-        ? new InMemoryFileSystem(snapshot, createPersistHook())
-        : bootstrapFileSystem();
+    const fs = (await loadFileSystem()) ?? bootstrapFileSystem();
     const kernel = new Kernel(fs);
     kernel.pendingNics = [
       { id: 'lo0', mac: '00:00:00:00:00:00', ip: '127.0.0.1', rx: [], tx: [] }


### PR DESCRIPTION
## Summary
- add async `loadFileSystem` helper
- use async loader when creating the kernel

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6847348dcf448324b0e62679eb977cfc