### PR TITLE
Fix networking snapshot hydration

### DIFF
--- a/core/snapshot.test.ts
+++ b/core/snapshot.test.ts
@@ -16,6 +16,22 @@ async function run() {
     const snap3 = restored2.snapshot();
     assert.strictEqual(checksum(snap2), checksum(snap3), 'snapshot checksums must match');
     console.log('Snapshot deterministic load test passed.');
+
+    const netKernel: any = new (Kernel as any)(new InMemoryFileSystem());
+    netKernel.startNetworking();
+    (await import('./services')).startHttpd(netKernel, { port: 8080 });
+    const sock = netKernel['state'].tcp.connect('127.0.0.1', 8080);
+    await netKernel['state'].tcp.send(sock, new Uint8Array([1, 2, 3]));
+    const netSnap1 = netKernel.snapshot();
+    const netRestored: any = await (Kernel as any).restore(netSnap1);
+    netRestored.startNetworking();
+    const netSnap2 = netRestored.snapshot();
+    assert.strictEqual(
+        checksum(netSnap1),
+        checksum(netSnap2),
+        'networked snapshot checksums must match'
+    );
+    console.log('Networked snapshot restore test passed.');
 }
 
 run();


### PR DESCRIPTION
## Summary
- hydrate networking classes when restoring kernel snapshots
- preserve NICs, TCP and UDP structures when snapshotting
- add regression test for networking state in snapshots

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68473698a05c8324a65136025520ab89