### PR TITLE
forward TTY info when spawning shells

### DIFF
--- a/core/fs/bin.ts
+++ b/core/fs/bin.ts
@@ -367,11 +367,12 @@ export const LOGIN_SOURCE = `
       return line;
     }
 
+    const ttyName = 'tty0';
     let tty;
     try {
-      tty = await syscall('open', '/dev/tty0', 'r');
+      tty = await syscall('open', '/dev/' + ttyName, 'r');
     } catch {
-      await syscall('write', STDERR_FD, encode('login: /dev/tty0 not found\n'));
+      await syscall('write', STDERR_FD, encode('login: /dev/' + ttyName + ' not found\n'));
       return 1;
     }
 
@@ -385,7 +386,7 @@ export const LOGIN_SOURCE = `
       const code = await readFile('/bin/bash');
       let m;
       try { m = JSON.parse(await readFile('/bin/bash.manifest.json')); } catch {}
-      await syscall('spawn', code, { syscalls: m ? m.syscalls : undefined });
+      await syscall('spawn', code, { syscalls: m ? m.syscalls : undefined, tty: ttyName });
     } catch {
       await syscall('write', STDERR_FD, encode('login: failed to launch shell\n'));
       return 1;


### PR DESCRIPTION
## Summary
- let login pass its TTY id when spawning `/bin/bash`
- keep `ProcessControlBlock` aware of an optional `tty`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68473c5f1efc832480822fe1ccf9a6c1