### PR TITLE
Add kernel job syscall and shell integration

### DIFF
--- a/core/fs/bin.ts
+++ b/core/fs/bin.ts
@@ -410,9 +410,15 @@ export const BASH_SOURCE = `
       if (line === 'exit') break;
 
       if (line === 'jobs') {
-        for (const j of jobs) {
+        let list;
+        try {
+          list = await syscall('jobs');
+        } catch {
+          list = jobs;
+        }
+        for (const j of list) {
           await syscall('write', STDOUT_FD,
-            encode('[' + j.id + '] ' + j.state + ' ' + j.command + '\n'));
+            encode('[' + j.id + '] ' + (j.status || j.state) + ' ' + j.command + '\n'));
         }
         continue;
       }
@@ -462,7 +468,7 @@ export const BASH_SOURCE = `
 
 export const BASH_MANIFEST = JSON.stringify({
   name: 'bash',
-  syscalls: ['open', 'read', 'write', 'close', 'spawn', 'ps']
+  syscalls: ['open', 'read', 'write', 'close', 'spawn', 'ps', 'jobs']
 });
 
 export const LOGIN_SOURCE = `

--- a/core/kernel.test.ts
+++ b/core/kernel.test.ts
@@ -110,6 +110,19 @@ async function run() {
   assert(slices >= 3, 'process should be requeued multiple times');
   console.log('Kernel scheduler timeslice test passed.');
 
+  // job table management
+  const jobKernel: any = new (Kernel as any)(new InMemoryFileSystem());
+  const jid = jobKernel.registerJob([123], 'sleep 1');
+  let jobList = jobKernel['syscall_jobs']();
+  assert.strictEqual(jobList.length, 1, 'job should register');
+  assert.strictEqual(jobList[0].id, jid, 'job id matches');
+  jobKernel.updateJobStatus(jid, 'Done');
+  jobList = jobKernel['syscall_jobs']();
+  assert.strictEqual(jobList[0].status, 'Done', 'status updates');
+  jobKernel.removeJob(jid);
+  assert.strictEqual(jobKernel['syscall_jobs']().length, 0, 'job removal');
+  console.log('Kernel job table test passed.');
+
   // snapshot save/load preserves fs hash and window list
   const snapKernel: any = new (Kernel as any)(new InMemoryFileSystem());
   snapKernel['state'].fs.createDirectory('/snap', 0o755);


### PR DESCRIPTION
## Summary
- implement job table helpers in kernel
- expose a `jobs` syscall
- let bash use the new syscall when available
- test kernel job reporting

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68474547bbec83248f88dbe2ad23de7e