### PR TITLE
Implement /proc pseudo filesystem

### DIFF
--- a/docs/kernel.md
+++ b/docs/kernel.md
@@ -69,6 +69,19 @@ PID %CPU %MEM TTY COMMAND
 3  0.0  0.1 ?   ps
 ```
 
+### `/proc` filesystem
+
+Runtime information is exposed through a virtual tree under `/proc`. Nothing is
+stored on disk; entries are generated on demand.
+
+- `/proc/<pid>/status` – text file with `pid`, `uid`, `cpuMs`, `memBytes`, `tty`
+  and command line.
+- `/proc/<pid>/fd/` – directory listing open descriptor numbers. Each file
+  contains the target path of that descriptor.
+
+This layout mirrors Linux behaviour and lets players introspect processes from
+userland utilities.
+
 ### Reboot and restore
 
 The `/sbin/reboot` command calls `kernel.reboot()`. This persists the current


### PR DESCRIPTION
## Summary
- add virtual-file descriptor support in kernel
- generate /proc entries dynamically for processes
- allow reading status and fd lists via procfs
- describe procfs in kernel docs
- test procfs functionality

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684746dd8dfc832491a83f424ef4066a