### PR TITLE
Handle ENOENT for /proc entries

### DIFF
--- a/core/kernel.test.ts
+++ b/core/kernel.test.ts
@@ -158,6 +158,21 @@ async function run() {
   const text = new TextDecoder().decode(stat);
   assert(text.includes('pid\t' + procPid) || text.includes('pid:\t' + procPid), 'status file readable');
   console.log('/proc filesystem test passed.');
+
+  try {
+    await procKernel['syscall_open'](procPcb, `/proc/${procPid + 1}/status`, 'r');
+    assert.fail('opening nonexistent /proc entry should throw');
+  } catch (e: any) {
+    assert(e.message.includes('ENOENT'), 'ENOENT expected for missing process');
+  }
+
+  try {
+    await procKernel['syscall_open'](procPcb, `/proc/${procPid}/fd/${procPcb.nextFd}`, 'r');
+    assert.fail('opening nonexistent fd should throw');
+  } catch (e: any) {
+    assert(e.message.includes('ENOENT'), 'ENOENT expected for missing fd');
+  }
+  console.log('Kernel /proc ENOENT tests passed.');
 }
 
 run();

--- a/core/kernel.ts
+++ b/core/kernel.ts
@@ -437,6 +437,24 @@ export class Kernel {
       if (parts.length < 3) {
         throw new Error(`EISDIR: illegal operation on a directory, open '${path}'`);
       }
+
+      const pid = parseInt(parts[1], 10);
+      const target = this.state.processes.get(pid);
+      if (!target) {
+        throw new Error(`ENOENT: no such file or directory, open '${path}'`);
+      }
+
+      if (parts[2] === 'status' && parts.length === 3) {
+        // valid
+      } else if (parts[2] === 'fd' && parts.length === 4) {
+        const vfd = parseInt(parts[3], 10);
+        if (!target.fds.has(vfd)) {
+          throw new Error(`ENOENT: no such file or directory, open '${path}'`);
+        }
+      } else {
+        throw new Error(`ENOENT: no such file or directory, open '${path}'`);
+      }
+
       const fd = pcb.nextFd++;
       pcb.fds.set(fd, { path, position: 0, flags, virtual: true });
       return fd;


### PR DESCRIPTION
## Summary
- validate `/proc` paths in `syscall_open`
- add unit tests for nonexistent `/proc` paths

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684751915bc08324bb72547848745927