### PR TITLE
Add ulimit syscall and CLI

### DIFF
--- a/apps/index.ts
+++ b/apps/index.ts
@@ -14,6 +14,7 @@ export * from './init';
 export * from './login';
 export * from './bash';
 export * from './snapshot';
+export * from './ulimit';
 
 import {
   NANO_SOURCE,
@@ -30,6 +31,7 @@ import {
   LOGIN_SOURCE,
   BASH_SOURCE,
   SNAPSHOT_SOURCE,
+  ULIMIT_SOURCE,
 } from '../core/fs/bin';
 
 export const BUNDLED_APPS = new Map<string, string>([
@@ -47,5 +49,6 @@ export const BUNDLED_APPS = new Map<string, string>([
   ['login', LOGIN_SOURCE],
   ['bash', BASH_SOURCE],
   ['snapshot', SNAPSHOT_SOURCE],
+  ['ulimit', ULIMIT_SOURCE],
 ]);
 

--- a/apps/ulimit.ts
+++ b/apps/ulimit.ts
@@ -1,0 +1,2 @@
+export { ULIMIT_SOURCE } from '../core/fs/bin';
+

--- a/core/kernel.ts
+++ b/core/kernel.ts
@@ -459,6 +459,8 @@ export class Kernel {
           return await this.syscall_mount(args[0], args[1]);
         case 'unmount':
           return await this.syscall_unmount(args[0]);
+        case 'set_quota':
+          return this.syscall_set_quota(pcb, args[0], args[1]);
         case 'kill':
           return this.syscall_kill(args[0], args[1]);
         case 'snapshot':
@@ -715,6 +717,16 @@ export class Kernel {
     fsClone.unmount(path);
     this.state.fs = fsClone;
     return 0;
+  }
+
+  private syscall_set_quota(pcb: ProcessControlBlock, ms?: number, mem?: number) {
+    if (typeof ms === 'number' && !isNaN(ms)) {
+      pcb.quotaMs = ms;
+    }
+    if (typeof mem === 'number' && !isNaN(mem)) {
+      pcb.quotaMem = mem;
+    }
+    return { quotaMs: pcb.quotaMs, quotaMem: pcb.quotaMem };
   }
 
   private syscall_ps() {


### PR DESCRIPTION
## Summary
- support `set_quota` syscall to change process limits
- add `/bin/ulimit` program for viewing and setting limits
- expose new ulimit app in bundle list
- update bash to track limits and pass them when spawning programs

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684769cee6ac8324b1df319c6dd5db91