### PR TITLE
Enable SQL plugin

### DIFF
--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -17,3 +17,4 @@ tokio = { version = "1.37", features = ["full"] }
 v8 = "137"
 once_cell = "1"
 serde_v8 = "0.259"
+tauri-plugin-sql = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1", package = "tauri-plugin-sql", features = ["sqlite"] }

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -341,6 +341,7 @@ async fn run_isolate_slice(
 
 fn main() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_sql::Builder::default().build())
         .invoke_handler(tauri::generate_handler![
             save_fs,
             load_fs,


### PR DESCRIPTION
## Summary
- integrate `tauri-plugin-sql` via git workspace
- register SQL plugin in Tauri builder

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6848327bdb44832480f660e440fdd63c