### PR TITLE
Add WAL checkpoint on shutdown

### DIFF
--- a/core/fs/persistent.ts
+++ b/core/fs/persistent.ts
@@ -427,6 +427,18 @@ export class PersistentFileSystem implements AsyncFileSystem {
         })
         this.cache.delete(path)
     }
+
+    /**
+     * Flush WAL and close the underlying database connection.
+     * Should be called during shutdown to keep the DB compact.
+     */
+    async close(): Promise<void> {
+        try {
+            await this.db.execute('PRAGMA wal_checkpoint(TRUNCATE)')
+        } finally {
+            await this.db.close()
+        }
+    }
 }
 
 export async function loadFileSystem(): Promise<PersistentFileSystem> {

--- a/core/kernel.ts
+++ b/core/kernel.ts
@@ -866,13 +866,20 @@ export class Kernel {
     }
   }
 
-  public stop(): void {
+  public async stop(): Promise<void> {
     persistKernelSnapshot(this.snapshot());
+    if ((this.state.fs as any).close) {
+      try {
+        await (this.state.fs as any).close();
+      } catch (e) {
+        console.error(e);
+      }
+    }
     this.running = false;
   }
 
-  public reboot(): void {
-    this.stop();
+  public async reboot(): Promise<void> {
+    await this.stop();
     eventBus.emit('system.reboot', {});
   }
 }


### PR DESCRIPTION
## Summary
- flush WAL on shutdown via a new `close()` method in `PersistentFileSystem`
- call this method from `Kernel.stop()` so shutdown and reboot compact the DB

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684840ecec6c83248d6e7793988088d6