### PR TITLE
Re-export kernel types

### DIFF
--- a/core/kernel/index.ts
+++ b/core/kernel/index.ts
@@ -463,3 +463,7 @@ export class Kernel {
     eventBus.emit('system.reboot', {});
   }
 }
+
+export type { ProcessID, FileDescriptor, ProcessControlBlock } from './process';
+export type { SyscallDispatcher } from './syscalls';
+


### PR DESCRIPTION
## Summary
- re-export ProcessID, FileDescriptor and ProcessControlBlock from `core/kernel/index.ts`
- re-export SyscallDispatcher from `core/kernel/syscalls.ts`
- verify tests

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68484dfe27448324bcf6486f67cf0dee