### PR TITLE
Refactor builtin app sources

### DIFF
--- a/apps/bin-src/bash.ts
+++ b/apps/bin-src/bash.ts
@@ -1,0 +1,164 @@
+export const BASH_SOURCE = `
+  async (syscall, argv) => {
+    const STDOUT_FD = 1;
+    const STDERR_FD = 2;
+    const encode = (s) => new TextEncoder().encode(s);
+    const decode = (b) => new TextDecoder().decode(b);
+
+    async function readFile(path) {
+      const fd = await syscall('open', path, 'r');
+      let out = '';
+      while (true) {
+        const chunk = await syscall('read', fd, 1024);
+        if (chunk.length === 0) break;
+        out += decode(chunk);
+      }
+      await syscall('close', fd);
+      return out;
+    }
+
+    async function readLine(fd) {
+      let line = '';
+      while (true) {
+        const chunk = await syscall('read', fd, 1);
+        if (chunk.length === 0) break;
+        const ch = decode(chunk);
+        if (ch === '\n') break;
+        line += ch;
+      }
+      return line;
+    }
+
+    async function waitPid(pid) {
+      while (true) {
+        const list = await syscall('ps');
+        const proc = list.find(p => p.pid === pid);
+        if (!proc || proc.exited) break;
+        await new Promise(r => setTimeout(r, 50));
+      }
+    }
+
+    const ttyName = argv[0] || 'tty0';
+    let tty;
+    try {
+      tty = await syscall('open', '/dev/' + ttyName, 'r');
+    } catch {
+      await syscall('write', STDERR_FD, encode('bash: unable to open tty\n'));
+      return 1;
+    }
+
+    const initLimits = await syscall('set_quota');
+    let quotaMs = initLimits.quotaMs;
+    let quotaMem = initLimits.quotaMem;
+
+    let nextJob = 1;
+    const jobs = [];
+
+    while (true) {
+      await syscall('write', STDOUT_FD, encode('$ '));
+      const line = (await readLine(tty)).trim();
+      if (!line) continue;
+      if (line === 'exit') break;
+
+      if (line === 'jobs') {
+        let list;
+        try {
+          list = await syscall('jobs');
+        } catch {
+          list = jobs;
+        }
+        for (const j of list) {
+          await syscall('write', STDOUT_FD,
+            encode('[' + j.id + '] ' + (j.status || j.state) + ' ' + j.command + '\n'));
+        }
+        continue;
+      }
+
+      if (line.startsWith('fg ')) {
+        const id = parseInt(line.slice(3).trim(), 10);
+        const job = jobs.find(j => j.id === id);
+        if (job) {
+          for (const pid of job.pids) {
+            await waitPid(pid);
+          }
+          job.state = 'Done';
+        }
+        continue;
+      }
+
+      if (line.startsWith('bg ')) {
+        const id = parseInt(line.slice(3).trim(), 10);
+        const job = jobs.find(j => j.id === id);
+        if (job) job.state = 'Running';
+        continue;
+      }
+
+      if (line.startsWith('ulimit')) {
+        const parts = line.split(/\s+/).slice(1);
+        if (parts.length === 0) {
+          await syscall('write', STDOUT_FD, encode('cpu ' + quotaMs + ' mem ' + quotaMem + '\n'));
+        } else {
+          for (let i = 0; i < parts.length; i++) {
+            if (parts[i] === '-t' && parts[i + 1]) {
+              quotaMs = parseInt(parts[i + 1], 10);
+              i++;
+            } else if (parts[i] === '-m' && parts[i + 1]) {
+              quotaMem = parseInt(parts[i + 1], 10);
+              i++;
+            }
+          }
+          await syscall('set_quota', quotaMs, quotaMem);
+        }
+        continue;
+      }
+
+      if (line.startsWith('kill')) {
+        const args = line.slice(4).trim().split(/\s+/).filter(a => a);
+        for (const arg of args) {
+          if (arg.startsWith('%')) {
+            const id = parseInt(arg.slice(1), 10);
+            let list;
+            try {
+              list = await syscall('jobs');
+            } catch {
+              list = jobs;
+            }
+            const job = list.find(j => j.id === id);
+            if (job) {
+              for (const pid of job.pids) {
+                await syscall('kill', pid);
+              }
+            }
+          } else {
+            const pid = parseInt(arg, 10);
+            if (!isNaN(pid)) {
+              await syscall('kill', pid);
+            }
+          }
+        }
+        continue;
+      }
+
+      const bg = line.endsWith('&');
+      const cmd = bg ? line.slice(0, -1).trim() : line;
+      const [name, ...args] = cmd.split(' ');
+      try {
+        const code = await readFile('/bin/' + name);
+        let m;
+        try { m = JSON.parse(await readFile('/bin/' + name + '.manifest.json')); } catch {}
+        const pid = await syscall('spawn', code, { argv: args, syscalls: m ? m.syscalls : undefined, tty: ttyName, quotaMs, quotaMem });
+        const job = { id: nextJob++, pids: [pid], command: cmd, state: 'Running' };
+        jobs.push(job);
+        if (!bg) {
+          await waitPid(pid);
+          job.state = 'Done';
+        }
+      } catch {
+        await syscall('write', STDERR_FD, encode('bash: ' + name + ': command not found\n'));
+      }
+    }
+
+    await syscall('close', tty);
+    return 0;
+  }
+`;

--- a/apps/bin-src/browser.ts
+++ b/apps/bin-src/browser.ts
@@ -1,0 +1,14 @@
+export const BROWSER_SOURCE = `
+  async (syscall, argv) => {
+    const STDERR_FD = 2;
+    const encode = (s) => new TextEncoder().encode(s);
+    if (argv.length === 0) {
+      await syscall('write', STDERR_FD, encode('browser: missing url\n'));
+      return 1;
+    }
+    const url = argv[0];
+    const html = '<h1>Requested URL: ' + url + '</h1>';
+    await syscall('draw', new TextEncoder().encode(html), { title: 'browser' });
+    return 0;
+  }
+`;

--- a/apps/bin-src/cat.ts
+++ b/apps/bin-src/cat.ts
@@ -1,0 +1,34 @@
+export const CAT_SOURCE = `
+  async (syscall, argv) => {
+    const STDOUT_FD = 1;
+    const STDERR_FD = 2;
+    const encode = (str) => new TextEncoder().encode(str);
+
+    if (argv.length === 0) {
+      await syscall('write', STDERR_FD, encode('cat: missing operand\\n'));
+      return 1;
+    }
+    const path = argv[0];
+    const READ_CHUNK_SIZE = 1024;
+    let fd = -1;
+
+    try {
+      fd = await syscall('open', path, 'r');
+      while (true) {
+        const data = await syscall('read', fd, READ_CHUNK_SIZE);
+        if (data.length === 0) {
+          break; // EOF
+        }
+        await syscall('write', STDOUT_FD, data);
+      }
+    } catch (e) {
+      await syscall('write', STDERR_FD, encode('cat: ' + path + ': ' + e.message + '\\n'));
+      return 1;
+    } finally {
+      if (fd >= 0) {
+        await syscall('close', fd);
+      }
+    }
+    return 0;
+  }
+`;

--- a/apps/bin-src/desktop.ts
+++ b/apps/bin-src/desktop.ts
@@ -1,0 +1,35 @@
+export const DESKTOP_SOURCE = `
+  async (syscall, argv) => {
+    const STDERR_FD = 2;
+    const encode = (s) => new TextEncoder().encode(s);
+    const decode = (b) => new TextDecoder().decode(b);
+
+    async function readFile(path) {
+      const fd = await syscall('open', path, 'r');
+      let out = '';
+      while (true) {
+        const chunk = await syscall('read', fd, 1024);
+        if (chunk.length === 0) break;
+        out += decode(chunk);
+      }
+      await syscall('close', fd);
+      return out;
+    }
+
+    const progs = argv.length > 0 ? argv : ['browser'];
+    for (const cmd of progs) {
+      const [name, ...args] = cmd.split(' ');
+      try {
+        const code = await readFile('/bin/' + name);
+        let m;
+        try {
+          m = JSON.parse(await readFile('/bin/' + name + '.manifest.json'));
+        } catch {}
+        await syscall('spawn', code, { argv: args, syscalls: m ? m.syscalls : undefined });
+      } catch {
+        await syscall('write', STDERR_FD, encode('desktop: failed to launch ' + name + '\n'));
+      }
+    }
+    return 0;
+  }
+`;

--- a/apps/bin-src/echo.ts
+++ b/apps/bin-src/echo.ts
@@ -1,0 +1,42 @@
+export const ECHO_SOURCE = `
+  async (syscall, argv) => {
+    const STDOUT_FD = 1;
+    const STDERR_FD = 2;
+    const encode = (str) => new TextEncoder().encode(str);
+    
+    let outputFd = STDOUT_FD;
+    let path = null;
+    let message = '';
+    const redirectionIndex = argv.indexOf('>');
+    
+    if (redirectionIndex > -1) {
+      path = argv[redirectionIndex + 1];
+      if (!path) {
+        await syscall('write', STDERR_FD, encode('echo: missing redirection file\\n'));
+        return 1;
+      }
+      message = argv.slice(0, redirectionIndex).join(' ') + '\\n';
+    } else {
+      message = argv.join(' ') + '\\n';
+    }
+
+    const bytes = encode(message);
+
+    try {
+      if (path) {
+        outputFd = await syscall('open', path, 'w');
+      }
+      if (bytes.length > 0) {
+        await syscall('write', outputFd, bytes);
+      }
+    } catch (e) {
+      await syscall('write', STDERR_FD, encode('echo: ' + e.message + '\\n'));
+      return 1;
+    } finally {
+      if (outputFd !== STDOUT_FD) {
+        await syscall('close', outputFd);
+      }
+    }
+    return 0;
+  }
+`; 

--- a/apps/bin-src/init.ts
+++ b/apps/bin-src/init.ts
@@ -1,0 +1,30 @@
+export const INIT_SOURCE = `
+  async (syscall, argv) => {
+    const STDERR_FD = 2;
+    const encode = (s) => new TextEncoder().encode(s);
+    const decode = (b) => new TextDecoder().decode(b);
+
+    async function readFile(path) {
+      const fd = await syscall('open', path, 'r');
+      let out = '';
+      while (true) {
+        const chunk = await syscall('read', fd, 1024);
+        if (chunk.length === 0) break;
+        out += decode(chunk);
+      }
+      await syscall('close', fd);
+      return out;
+    }
+
+    try {
+      const code = await readFile('/bin/login');
+      let m;
+      try { m = JSON.parse(await readFile('/bin/login.manifest.json')); } catch {}
+      await syscall('spawn', code, { syscalls: m ? m.syscalls : undefined });
+    } catch {
+      await syscall('write', STDERR_FD, encode('init: failed to launch login\n'));
+      return 1;
+    }
+    return 0;
+  }
+`;

--- a/apps/bin-src/kill.ts
+++ b/apps/bin-src/kill.ts
@@ -1,0 +1,22 @@
+export const KILL_SOURCE = `
+  async (syscall, argv) => {
+    const pids = [];
+    for (const arg of argv) {
+      if (arg.startsWith('%')) {
+        const id = parseInt(arg.slice(1), 10);
+        try {
+          const list = await syscall('jobs');
+          const job = list.find(j => j.id === id);
+          if (job) pids.push(...job.pids);
+        } catch {}
+      } else {
+        const pid = parseInt(arg, 10);
+        if (!isNaN(pid)) pids.push(pid);
+      }
+    }
+    for (const pid of pids) {
+      try { await syscall('kill', pid); } catch {}
+    }
+    return 0;
+  }
+`;

--- a/apps/bin-src/login.ts
+++ b/apps/bin-src/login.ts
@@ -1,0 +1,58 @@
+export const LOGIN_SOURCE = `
+  async (syscall, argv) => {
+    const STDOUT_FD = 1;
+    const STDERR_FD = 2;
+    const encode = (s) => new TextEncoder().encode(s);
+    const decode = (b) => new TextDecoder().decode(b);
+
+    async function readFile(path) {
+      const fd = await syscall('open', path, 'r');
+      let out = '';
+      while (true) {
+        const chunk = await syscall('read', fd, 1024);
+        if (chunk.length === 0) break;
+        out += decode(chunk);
+      }
+      await syscall('close', fd);
+      return out;
+    }
+
+    async function readLine(fd) {
+      let line = '';
+      while (true) {
+        const chunk = await syscall('read', fd, 1);
+        if (chunk.length === 0) break;
+        const ch = decode(chunk);
+        if (ch === '\n') break;
+        line += ch;
+      }
+      return line;
+    }
+
+    const ttyName = 'tty0';
+    let tty;
+    try {
+      tty = await syscall('open', '/dev/' + ttyName, 'r');
+    } catch {
+      await syscall('write', STDERR_FD, encode('login: /dev/' + ttyName + ' not found\n'));
+      return 1;
+    }
+
+    await syscall('write', STDOUT_FD, encode('login: '));
+    await readLine(tty);
+    await syscall('write', STDOUT_FD, encode('password: '));
+    await readLine(tty);
+    await syscall('close', tty);
+
+    try {
+      const code = await readFile('/bin/bash');
+      let m;
+      try { m = JSON.parse(await readFile('/bin/bash.manifest.json')); } catch {}
+      await syscall('spawn', code, { syscalls: m ? m.syscalls : undefined, tty: ttyName });
+    } catch {
+      await syscall('write', STDERR_FD, encode('login: failed to launch shell\n'));
+      return 1;
+    }
+    return 0;
+  }
+`;

--- a/apps/bin-src/ls.ts
+++ b/apps/bin-src/ls.ts
@@ -1,0 +1,17 @@
+export const LS_SOURCE = `
+  async (syscall, argv) => {
+    const STDOUT_FD = 1;
+    const STDERR_FD = 2;
+    const encode = (s) => new TextEncoder().encode(s);
+    const path = argv[0] || '/';
+    try {
+      const entries = await syscall('readdir', path);
+      const names = entries.map(e => e.path.split('/').pop()).join('\n') + '\n';
+      await syscall('write', STDOUT_FD, encode(names));
+    } catch (e) {
+      await syscall('write', STDERR_FD, encode('ls: ' + e.message + '\n'));
+      return 1;
+    }
+    return 0;
+  }
+`;

--- a/apps/bin-src/mkdir.ts
+++ b/apps/bin-src/mkdir.ts
@@ -1,0 +1,17 @@
+export const MKDIR_SOURCE = `
+  async (syscall, argv) => {
+    const STDERR_FD = 2;
+    const encode = (s) => new TextEncoder().encode(s);
+    if (argv.length === 0) {
+      await syscall('write', STDERR_FD, encode('mkdir: missing operand\n'));
+      return 1;
+    }
+    try {
+      await syscall('mkdir', argv[0], 0o755);
+    } catch (e) {
+      await syscall('write', STDERR_FD, encode('mkdir: ' + e.message + '\n'));
+      return 1;
+    }
+    return 0;
+  }
+`;

--- a/apps/bin-src/mv.ts
+++ b/apps/bin-src/mv.ts
@@ -1,0 +1,17 @@
+export const MV_SOURCE = `
+  async (syscall, argv) => {
+    const STDERR_FD = 2;
+    const encode = (s) => new TextEncoder().encode(s);
+    if (argv.length < 2) {
+      await syscall('write', STDERR_FD, encode('mv: missing operand\n'));
+      return 1;
+    }
+    try {
+      await syscall('rename', argv[0], argv[1]);
+    } catch (e) {
+      await syscall('write', STDERR_FD, encode('mv: ' + e.message + '\n'));
+      return 1;
+    }
+    return 0;
+  }
+`;

--- a/apps/bin-src/nano.ts
+++ b/apps/bin-src/nano.ts
@@ -1,0 +1,30 @@
+export const NANO_SOURCE = `
+  async (syscall, argv) => {
+    const STDERR_FD = 2;
+    const encode = (s) => new TextEncoder().encode(s);
+    if (argv.length === 0) {
+      await syscall('write', STDERR_FD, encode('nano: missing file\n'));
+      return 1;
+    }
+    const path = argv[0];
+    let content = '';
+    try {
+      const fd = await syscall('open', path, 'r');
+      while (true) {
+        const chunk = await syscall('read', fd, 1024);
+        if (chunk.length === 0) break;
+        content += new TextDecoder().decode(chunk);
+      }
+      await syscall('close', fd);
+    } catch (e) {
+      // new file - start empty
+    }
+    const escaped = content
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+    const html = '<pre>' + escaped + '</pre>';
+    await syscall('draw', new TextEncoder().encode(html), { title: 'nano - ' + path });
+    return 0;
+  }
+`;

--- a/apps/bin-src/ping.ts
+++ b/apps/bin-src/ping.ts
@@ -1,0 +1,24 @@
+export const PING_SOURCE = `
+  async (syscall, argv) => {
+    const STDOUT_FD = 1;
+    const STDERR_FD = 2;
+    const encode = (s) => new TextEncoder().encode(s);
+    const ip = argv[0] || '127.0.0.1';
+    const port = argv[1] ? parseInt(argv[1], 10) : 7;
+    try {
+      const sock = await syscall('connect', ip, port);
+      const start = Date.now();
+      const resp = await syscall('tcp_send', sock, encode('ping'));
+      const end = Date.now();
+      if (resp) {
+        await syscall('write', STDOUT_FD, encode('pong ' + (end - start) + 'ms\n'));
+      } else {
+        await syscall('write', STDERR_FD, encode('no response\n'));
+      }
+    } catch (e) {
+      await syscall('write', STDERR_FD, encode('ping: ' + e.message + '\n'));
+      return 1;
+    }
+    return 0;
+  }
+`;

--- a/apps/bin-src/ps.ts
+++ b/apps/bin-src/ps.ts
@@ -1,0 +1,22 @@
+export const PS_SOURCE = `
+  async (syscall, argv) => {
+    const STDOUT_FD = 1;
+    const encode = (s) => new TextEncoder().encode(s);
+    const procs = await syscall('ps');
+
+    const totalCpu = procs.reduce((n, p) => n + (p.cpuMs || 0), 0);
+    const totalMem = procs.reduce((n, p) => n + (p.memBytes || 0), 0);
+
+    let lines = 'PID %CPU %MEM TTY COMMAND\n';
+    for (const p of procs) {
+      const cpu = totalCpu ? ((p.cpuMs || 0) / totalCpu * 100).toFixed(1) : '0.0';
+      const mem = totalMem ? ((p.memBytes || 0) / totalMem * 100).toFixed(1) : '0.0';
+      const tty = p.tty ? p.tty : '?';
+      const cmd = p.argv ? p.argv.join(' ') : '';
+      lines += p.pid + ' ' + cpu + ' ' + mem + ' ' + tty + ' ' + cmd + '\n';
+    }
+
+    await syscall('write', STDOUT_FD, encode(lines));
+    return 0;
+  }
+`;

--- a/apps/bin-src/reboot.ts
+++ b/apps/bin-src/reboot.ts
@@ -1,0 +1,6 @@
+export const REBOOT_SOURCE = `
+  async (syscall) => {
+    await syscall('reboot');
+    return 0;
+  }
+`;

--- a/apps/bin-src/rm.ts
+++ b/apps/bin-src/rm.ts
@@ -1,0 +1,17 @@
+export const RM_SOURCE = `
+  async (syscall, argv) => {
+    const STDERR_FD = 2;
+    const encode = (s) => new TextEncoder().encode(s);
+    if (argv.length === 0) {
+      await syscall('write', STDERR_FD, encode('rm: missing operand\n'));
+      return 1;
+    }
+    try {
+      await syscall('unlink', argv[0]);
+    } catch (e) {
+      await syscall('write', STDERR_FD, encode('rm: ' + e.message + '\n'));
+      return 1;
+    }
+    return 0;
+  }
+`;

--- a/apps/bin-src/sleep.ts
+++ b/apps/bin-src/sleep.ts
@@ -1,0 +1,7 @@
+export const SLEEP_SOURCE = `
+  async (_syscall, argv) => {
+    const ms = parseInt(argv[0] || '1', 10) * 1000;
+    await new Promise(r => setTimeout(r, ms));
+    return 0;
+  }
+`;

--- a/apps/bin-src/snapshot.ts
+++ b/apps/bin-src/snapshot.ts
@@ -1,0 +1,29 @@
+export const SNAPSHOT_SOURCE = `
+  async (syscall, argv) => {
+    const STDERR_FD = 2;
+    const encode = (s) => new TextEncoder().encode(s);
+
+    if (argv.length < 2) {
+      await syscall('write', STDERR_FD, encode('usage: snapshot <save|load> <name>\n'));
+      return 1;
+    }
+
+    const action = argv[0];
+    const name = argv[1];
+
+    if (action === 'save') {
+      const snap = await syscall('snapshot');
+      await syscall('save_snapshot_named', name, snap);
+      return 0;
+    }
+
+    if (action === 'load') {
+      await syscall('load_snapshot_named', name);
+      await syscall('reboot');
+      return 0;
+    }
+
+    await syscall('write', STDERR_FD, encode('snapshot: unknown action\n'));
+    return 1;
+  }
+`;

--- a/apps/bin-src/ulimit.ts
+++ b/apps/bin-src/ulimit.ts
@@ -1,0 +1,26 @@
+export const ULIMIT_SOURCE = `
+  async (syscall, argv) => {
+    const STDOUT_FD = 1;
+    const encode = (s) => new TextEncoder().encode(s);
+
+    if (argv.length === 0) {
+      const res = await syscall('set_quota');
+      await syscall('write', STDOUT_FD, encode('cpu ' + res.quotaMs + ' mem ' + res.quotaMem + '\n'));
+      return 0;
+    }
+
+    let ms;
+    let mem;
+    for (let i = 0; i < argv.length; i++) {
+      if (argv[i] === '-t') {
+        ms = parseInt(argv[i + 1] || '0', 10);
+        i++;
+      } else if (argv[i] === '-m') {
+        mem = parseInt(argv[i + 1] || '0', 10);
+        i++;
+      }
+    }
+    await syscall('set_quota', ms, mem);
+    return 0;
+  }
+`;

--- a/apps/index.ts
+++ b/apps/index.ts
@@ -16,39 +16,5 @@ export * from './bash';
 export * from './snapshot';
 export * from './ulimit';
 
-import {
-  NANO_SOURCE,
-  BROWSER_SOURCE,
-  PING_SOURCE,
-  DESKTOP_SOURCE,
-  LS_SOURCE,
-  MKDIR_SOURCE,
-  RM_SOURCE,
-  MV_SOURCE,
-  PS_SOURCE,
-  KILL_SOURCE,
-  INIT_SOURCE,
-  LOGIN_SOURCE,
-  BASH_SOURCE,
-  SNAPSHOT_SOURCE,
-  ULIMIT_SOURCE,
-} from '../core/fs/bin';
-
-export const BUNDLED_APPS = new Map<string, string>([
-  ['nano', NANO_SOURCE],
-  ['browser', BROWSER_SOURCE],
-  ['ping', PING_SOURCE],
-  ['desktop', DESKTOP_SOURCE],
-  ['ls', LS_SOURCE],
-  ['mkdir', MKDIR_SOURCE],
-  ['rm', RM_SOURCE],
-  ['mv', MV_SOURCE],
-  ['ps', PS_SOURCE],
-  ['kill', KILL_SOURCE],
-  ['init', INIT_SOURCE],
-  ['login', LOGIN_SOURCE],
-  ['bash', BASH_SOURCE],
-  ['snapshot', SNAPSHOT_SOURCE],
-  ['ulimit', ULIMIT_SOURCE],
-]);
+export { BUNDLED_APPS } from '../core/fs/bin';
 

--- a/core/fs/bin.ts
+++ b/core/fs/bin.ts
@@ -2,309 +2,25 @@
  * This file contains the source code for the initial binary programs
  * that will be loaded into the virtual file system.
  */
-
-export const CAT_SOURCE = `
-  async (syscall, argv) => {
-    const STDOUT_FD = 1;
-    const STDERR_FD = 2;
-    const encode = (str) => new TextEncoder().encode(str);
-
-    if (argv.length === 0) {
-      await syscall('write', STDERR_FD, encode('cat: missing operand\\n'));
-      return 1;
-    }
-    const path = argv[0];
-    const READ_CHUNK_SIZE = 1024;
-    let fd = -1;
-
-    try {
-      fd = await syscall('open', path, 'r');
-      while (true) {
-        const data = await syscall('read', fd, READ_CHUNK_SIZE);
-        if (data.length === 0) {
-          break; // EOF
-        }
-        await syscall('write', STDOUT_FD, data);
-      }
-    } catch (e) {
-      await syscall('write', STDERR_FD, encode('cat: ' + path + ': ' + e.message + '\\n'));
-      return 1;
-    } finally {
-      if (fd >= 0) {
-        await syscall('close', fd);
-      }
-    }
-    return 0;
-  }
-`;
-
-export const ECHO_SOURCE = `
-  async (syscall, argv) => {
-    const STDOUT_FD = 1;
-    const STDERR_FD = 2;
-    const encode = (str) => new TextEncoder().encode(str);
-    
-    let outputFd = STDOUT_FD;
-    let path = null;
-    let message = '';
-    const redirectionIndex = argv.indexOf('>');
-    
-    if (redirectionIndex > -1) {
-      path = argv[redirectionIndex + 1];
-      if (!path) {
-        await syscall('write', STDERR_FD, encode('echo: missing redirection file\\n'));
-        return 1;
-      }
-      message = argv.slice(0, redirectionIndex).join(' ') + '\\n';
-    } else {
-      message = argv.join(' ') + '\\n';
-    }
-
-    const bytes = encode(message);
-
-    try {
-      if (path) {
-        outputFd = await syscall('open', path, 'w');
-      }
-      if (bytes.length > 0) {
-        await syscall('write', outputFd, bytes);
-      }
-    } catch (e) {
-      await syscall('write', STDERR_FD, encode('echo: ' + e.message + '\\n'));
-      return 1;
-    } finally {
-      if (outputFd !== STDOUT_FD) {
-        await syscall('close', outputFd);
-      }
-    }
-    return 0;
-  }
-`; 
-export const NANO_SOURCE = `
-  async (syscall, argv) => {
-    const STDERR_FD = 2;
-    const encode = (s) => new TextEncoder().encode(s);
-    if (argv.length === 0) {
-      await syscall('write', STDERR_FD, encode('nano: missing file\n'));
-      return 1;
-    }
-    const path = argv[0];
-    let content = '';
-    try {
-      const fd = await syscall('open', path, 'r');
-      while (true) {
-        const chunk = await syscall('read', fd, 1024);
-        if (chunk.length === 0) break;
-        content += new TextDecoder().decode(chunk);
-      }
-      await syscall('close', fd);
-    } catch (e) {
-      // new file - start empty
-    }
-    const escaped = content
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;');
-    const html = '<pre>' + escaped + '</pre>';
-    await syscall('draw', new TextEncoder().encode(html), { title: 'nano - ' + path });
-    return 0;
-  }
-`;
-
-export const BROWSER_SOURCE = `
-  async (syscall, argv) => {
-    const STDERR_FD = 2;
-    const encode = (s) => new TextEncoder().encode(s);
-    if (argv.length === 0) {
-      await syscall('write', STDERR_FD, encode('browser: missing url\n'));
-      return 1;
-    }
-    const url = argv[0];
-    const html = '<h1>Requested URL: ' + url + '</h1>';
-    await syscall('draw', new TextEncoder().encode(html), { title: 'browser' });
-    return 0;
-  }
-`;
-
-export const PING_SOURCE = `
-  async (syscall, argv) => {
-    const STDOUT_FD = 1;
-    const STDERR_FD = 2;
-    const encode = (s) => new TextEncoder().encode(s);
-    const ip = argv[0] || '127.0.0.1';
-    const port = argv[1] ? parseInt(argv[1], 10) : 7;
-    try {
-      const sock = await syscall('connect', ip, port);
-      const start = Date.now();
-      const resp = await syscall('tcp_send', sock, encode('ping'));
-      const end = Date.now();
-      if (resp) {
-        await syscall('write', STDOUT_FD, encode('pong ' + (end - start) + 'ms\n'));
-      } else {
-        await syscall('write', STDERR_FD, encode('no response\n'));
-      }
-    } catch (e) {
-      await syscall('write', STDERR_FD, encode('ping: ' + e.message + '\n'));
-      return 1;
-    }
-    return 0;
-  }
-`;
-
-export const DESKTOP_SOURCE = `
-  async (syscall, argv) => {
-    const STDERR_FD = 2;
-    const encode = (s) => new TextEncoder().encode(s);
-    const decode = (b) => new TextDecoder().decode(b);
-
-    async function readFile(path) {
-      const fd = await syscall('open', path, 'r');
-      let out = '';
-      while (true) {
-        const chunk = await syscall('read', fd, 1024);
-        if (chunk.length === 0) break;
-        out += decode(chunk);
-      }
-      await syscall('close', fd);
-      return out;
-    }
-
-    const progs = argv.length > 0 ? argv : ['browser'];
-    for (const cmd of progs) {
-      const [name, ...args] = cmd.split(' ');
-      try {
-        const code = await readFile('/bin/' + name);
-        let m;
-        try {
-          m = JSON.parse(await readFile('/bin/' + name + '.manifest.json'));
-        } catch {}
-        await syscall('spawn', code, { argv: args, syscalls: m ? m.syscalls : undefined });
-      } catch {
-        await syscall('write', STDERR_FD, encode('desktop: failed to launch ' + name + '\n'));
-      }
-    }
-    return 0;
-  }
-`;
-
-export const LS_SOURCE = `
-  async (syscall, argv) => {
-    const STDOUT_FD = 1;
-    const STDERR_FD = 2;
-    const encode = (s) => new TextEncoder().encode(s);
-    const path = argv[0] || '/';
-    try {
-      const entries = await syscall('readdir', path);
-      const names = entries.map(e => e.path.split('/').pop()).join('\n') + '\n';
-      await syscall('write', STDOUT_FD, encode(names));
-    } catch (e) {
-      await syscall('write', STDERR_FD, encode('ls: ' + e.message + '\n'));
-      return 1;
-    }
-    return 0;
-  }
-`;
-
-export const MKDIR_SOURCE = `
-  async (syscall, argv) => {
-    const STDERR_FD = 2;
-    const encode = (s) => new TextEncoder().encode(s);
-    if (argv.length === 0) {
-      await syscall('write', STDERR_FD, encode('mkdir: missing operand\n'));
-      return 1;
-    }
-    try {
-      await syscall('mkdir', argv[0], 0o755);
-    } catch (e) {
-      await syscall('write', STDERR_FD, encode('mkdir: ' + e.message + '\n'));
-      return 1;
-    }
-    return 0;
-  }
-`;
-
-export const RM_SOURCE = `
-  async (syscall, argv) => {
-    const STDERR_FD = 2;
-    const encode = (s) => new TextEncoder().encode(s);
-    if (argv.length === 0) {
-      await syscall('write', STDERR_FD, encode('rm: missing operand\n'));
-      return 1;
-    }
-    try {
-      await syscall('unlink', argv[0]);
-    } catch (e) {
-      await syscall('write', STDERR_FD, encode('rm: ' + e.message + '\n'));
-      return 1;
-    }
-    return 0;
-  }
-`;
-
-export const MV_SOURCE = `
-  async (syscall, argv) => {
-    const STDERR_FD = 2;
-    const encode = (s) => new TextEncoder().encode(s);
-    if (argv.length < 2) {
-      await syscall('write', STDERR_FD, encode('mv: missing operand\n'));
-      return 1;
-    }
-    try {
-      await syscall('rename', argv[0], argv[1]);
-    } catch (e) {
-      await syscall('write', STDERR_FD, encode('mv: ' + e.message + '\n'));
-      return 1;
-    }
-    return 0;
-  }
-`;
-
-export const PS_SOURCE = `
-  async (syscall, argv) => {
-    const STDOUT_FD = 1;
-    const encode = (s) => new TextEncoder().encode(s);
-    const procs = await syscall('ps');
-
-    const totalCpu = procs.reduce((n, p) => n + (p.cpuMs || 0), 0);
-    const totalMem = procs.reduce((n, p) => n + (p.memBytes || 0), 0);
-
-    let lines = 'PID %CPU %MEM TTY COMMAND\n';
-    for (const p of procs) {
-      const cpu = totalCpu ? ((p.cpuMs || 0) / totalCpu * 100).toFixed(1) : '0.0';
-      const mem = totalMem ? ((p.memBytes || 0) / totalMem * 100).toFixed(1) : '0.0';
-      const tty = p.tty ? p.tty : '?';
-      const cmd = p.argv ? p.argv.join(' ') : '';
-      lines += p.pid + ' ' + cpu + ' ' + mem + ' ' + tty + ' ' + cmd + '\n';
-    }
-
-    await syscall('write', STDOUT_FD, encode(lines));
-    return 0;
-  }
-`;
-
-export const KILL_SOURCE = `
-  async (syscall, argv) => {
-    const pids = [];
-    for (const arg of argv) {
-      if (arg.startsWith('%')) {
-        const id = parseInt(arg.slice(1), 10);
-        try {
-          const list = await syscall('jobs');
-          const job = list.find(j => j.id === id);
-          if (job) pids.push(...job.pids);
-        } catch {}
-      } else {
-        const pid = parseInt(arg, 10);
-        if (!isNaN(pid)) pids.push(pid);
-      }
-    }
-    for (const pid of pids) {
-      try { await syscall('kill', pid); } catch {}
-    }
-    return 0;
-  }
-`;
-
+import { CAT_SOURCE } from '../../apps/bin-src/cat';
+import { ECHO_SOURCE } from '../../apps/bin-src/echo';
+import { NANO_SOURCE } from '../../apps/bin-src/nano';
+import { BROWSER_SOURCE } from '../../apps/bin-src/browser';
+import { PING_SOURCE } from '../../apps/bin-src/ping';
+import { DESKTOP_SOURCE } from '../../apps/bin-src/desktop';
+import { LS_SOURCE } from '../../apps/bin-src/ls';
+import { MKDIR_SOURCE } from '../../apps/bin-src/mkdir';
+import { RM_SOURCE } from '../../apps/bin-src/rm';
+import { MV_SOURCE } from '../../apps/bin-src/mv';
+import { PS_SOURCE } from '../../apps/bin-src/ps';
+import { KILL_SOURCE } from '../../apps/bin-src/kill';
+import { SLEEP_SOURCE } from '../../apps/bin-src/sleep';
+import { ULIMIT_SOURCE } from '../../apps/bin-src/ulimit';
+import { BASH_SOURCE } from '../../apps/bin-src/bash';
+import { LOGIN_SOURCE } from '../../apps/bin-src/login';
+import { INIT_SOURCE } from '../../apps/bin-src/init';
+import { REBOOT_SOURCE } from '../../apps/bin-src/reboot';
+import { SNAPSHOT_SOURCE } from '../../apps/bin-src/snapshot';
 
 export const CAT_MANIFEST = JSON.stringify({
   name: 'cat',
@@ -366,365 +82,78 @@ export const KILL_MANIFEST = JSON.stringify({
     syscalls: ['kill', 'jobs']
 });
 
-export const SLEEP_SOURCE = `
-  async (_syscall, argv) => {
-    const ms = parseInt(argv[0] || '1', 10) * 1000;
-    await new Promise(r => setTimeout(r, ms));
-    return 0;
-  }
-`;
-
 export const SLEEP_MANIFEST = JSON.stringify({
   name: 'sleep',
   syscalls: []
 });
-
-export const ULIMIT_SOURCE = `
-  async (syscall, argv) => {
-    const STDOUT_FD = 1;
-    const encode = (s) => new TextEncoder().encode(s);
-
-    if (argv.length === 0) {
-      const res = await syscall('set_quota');
-      await syscall('write', STDOUT_FD, encode('cpu ' + res.quotaMs + ' mem ' + res.quotaMem + '\n'));
-      return 0;
-    }
-
-    let ms;
-    let mem;
-    for (let i = 0; i < argv.length; i++) {
-      if (argv[i] === '-t') {
-        ms = parseInt(argv[i + 1] || '0', 10);
-        i++;
-      } else if (argv[i] === '-m') {
-        mem = parseInt(argv[i + 1] || '0', 10);
-        i++;
-      }
-    }
-    await syscall('set_quota', ms, mem);
-    return 0;
-  }
-`;
 
 export const ULIMIT_MANIFEST = JSON.stringify({
   name: 'ulimit',
   syscalls: ['set_quota', 'write']
 });
 
-export const BASH_SOURCE = `
-  async (syscall, argv) => {
-    const STDOUT_FD = 1;
-    const STDERR_FD = 2;
-    const encode = (s) => new TextEncoder().encode(s);
-    const decode = (b) => new TextDecoder().decode(b);
-
-    async function readFile(path) {
-      const fd = await syscall('open', path, 'r');
-      let out = '';
-      while (true) {
-        const chunk = await syscall('read', fd, 1024);
-        if (chunk.length === 0) break;
-        out += decode(chunk);
-      }
-      await syscall('close', fd);
-      return out;
-    }
-
-    async function readLine(fd) {
-      let line = '';
-      while (true) {
-        const chunk = await syscall('read', fd, 1);
-        if (chunk.length === 0) break;
-        const ch = decode(chunk);
-        if (ch === '\n') break;
-        line += ch;
-      }
-      return line;
-    }
-
-    async function waitPid(pid) {
-      while (true) {
-        const list = await syscall('ps');
-        const proc = list.find(p => p.pid === pid);
-        if (!proc || proc.exited) break;
-        await new Promise(r => setTimeout(r, 50));
-      }
-    }
-
-    const ttyName = argv[0] || 'tty0';
-    let tty;
-    try {
-      tty = await syscall('open', '/dev/' + ttyName, 'r');
-    } catch {
-      await syscall('write', STDERR_FD, encode('bash: unable to open tty\n'));
-      return 1;
-    }
-
-    const initLimits = await syscall('set_quota');
-    let quotaMs = initLimits.quotaMs;
-    let quotaMem = initLimits.quotaMem;
-
-    let nextJob = 1;
-    const jobs = [];
-
-    while (true) {
-      await syscall('write', STDOUT_FD, encode('$ '));
-      const line = (await readLine(tty)).trim();
-      if (!line) continue;
-      if (line === 'exit') break;
-
-      if (line === 'jobs') {
-        let list;
-        try {
-          list = await syscall('jobs');
-        } catch {
-          list = jobs;
-        }
-        for (const j of list) {
-          await syscall('write', STDOUT_FD,
-            encode('[' + j.id + '] ' + (j.status || j.state) + ' ' + j.command + '\n'));
-        }
-        continue;
-      }
-
-      if (line.startsWith('fg ')) {
-        const id = parseInt(line.slice(3).trim(), 10);
-        const job = jobs.find(j => j.id === id);
-        if (job) {
-          for (const pid of job.pids) {
-            await waitPid(pid);
-          }
-          job.state = 'Done';
-        }
-        continue;
-      }
-
-      if (line.startsWith('bg ')) {
-        const id = parseInt(line.slice(3).trim(), 10);
-        const job = jobs.find(j => j.id === id);
-        if (job) job.state = 'Running';
-        continue;
-      }
-
-      if (line.startsWith('ulimit')) {
-        const parts = line.split(/\s+/).slice(1);
-        if (parts.length === 0) {
-          await syscall('write', STDOUT_FD, encode('cpu ' + quotaMs + ' mem ' + quotaMem + '\n'));
-        } else {
-          for (let i = 0; i < parts.length; i++) {
-            if (parts[i] === '-t' && parts[i + 1]) {
-              quotaMs = parseInt(parts[i + 1], 10);
-              i++;
-            } else if (parts[i] === '-m' && parts[i + 1]) {
-              quotaMem = parseInt(parts[i + 1], 10);
-              i++;
-            }
-          }
-          await syscall('set_quota', quotaMs, quotaMem);
-        }
-        continue;
-      }
-
-      if (line.startsWith('kill')) {
-        const args = line.slice(4).trim().split(/\s+/).filter(a => a);
-        for (const arg of args) {
-          if (arg.startsWith('%')) {
-            const id = parseInt(arg.slice(1), 10);
-            let list;
-            try {
-              list = await syscall('jobs');
-            } catch {
-              list = jobs;
-            }
-            const job = list.find(j => j.id === id);
-            if (job) {
-              for (const pid of job.pids) {
-                await syscall('kill', pid);
-              }
-            }
-          } else {
-            const pid = parseInt(arg, 10);
-            if (!isNaN(pid)) {
-              await syscall('kill', pid);
-            }
-          }
-        }
-        continue;
-      }
-
-      const bg = line.endsWith('&');
-      const cmd = bg ? line.slice(0, -1).trim() : line;
-      const [name, ...args] = cmd.split(' ');
-      try {
-        const code = await readFile('/bin/' + name);
-        let m;
-        try { m = JSON.parse(await readFile('/bin/' + name + '.manifest.json')); } catch {}
-        const pid = await syscall('spawn', code, { argv: args, syscalls: m ? m.syscalls : undefined, tty: ttyName, quotaMs, quotaMem });
-        const job = { id: nextJob++, pids: [pid], command: cmd, state: 'Running' };
-        jobs.push(job);
-        if (!bg) {
-          await waitPid(pid);
-          job.state = 'Done';
-        }
-      } catch {
-        await syscall('write', STDERR_FD, encode('bash: ' + name + ': command not found\n'));
-      }
-    }
-
-    await syscall('close', tty);
-    return 0;
-  }
-`;
-
 export const BASH_MANIFEST = JSON.stringify({
   name: 'bash',
   syscalls: ['open', 'read', 'write', 'close', 'spawn', 'ps', 'jobs', 'kill', 'set_quota']
 });
-
-export const LOGIN_SOURCE = `
-  async (syscall, argv) => {
-    const STDOUT_FD = 1;
-    const STDERR_FD = 2;
-    const encode = (s) => new TextEncoder().encode(s);
-    const decode = (b) => new TextDecoder().decode(b);
-
-    async function readFile(path) {
-      const fd = await syscall('open', path, 'r');
-      let out = '';
-      while (true) {
-        const chunk = await syscall('read', fd, 1024);
-        if (chunk.length === 0) break;
-        out += decode(chunk);
-      }
-      await syscall('close', fd);
-      return out;
-    }
-
-    async function readLine(fd) {
-      let line = '';
-      while (true) {
-        const chunk = await syscall('read', fd, 1);
-        if (chunk.length === 0) break;
-        const ch = decode(chunk);
-        if (ch === '\n') break;
-        line += ch;
-      }
-      return line;
-    }
-
-    const ttyName = 'tty0';
-    let tty;
-    try {
-      tty = await syscall('open', '/dev/' + ttyName, 'r');
-    } catch {
-      await syscall('write', STDERR_FD, encode('login: /dev/' + ttyName + ' not found\n'));
-      return 1;
-    }
-
-    await syscall('write', STDOUT_FD, encode('login: '));
-    await readLine(tty);
-    await syscall('write', STDOUT_FD, encode('password: '));
-    await readLine(tty);
-    await syscall('close', tty);
-
-    try {
-      const code = await readFile('/bin/bash');
-      let m;
-      try { m = JSON.parse(await readFile('/bin/bash.manifest.json')); } catch {}
-      await syscall('spawn', code, { syscalls: m ? m.syscalls : undefined, tty: ttyName });
-    } catch {
-      await syscall('write', STDERR_FD, encode('login: failed to launch shell\n'));
-      return 1;
-    }
-    return 0;
-  }
-`;
 
 export const LOGIN_MANIFEST = JSON.stringify({
   name: 'login',
   syscalls: ['open', 'read', 'write', 'close', 'spawn']
 });
 
-export const INIT_SOURCE = `
-  async (syscall, argv) => {
-    const STDERR_FD = 2;
-    const encode = (s) => new TextEncoder().encode(s);
-    const decode = (b) => new TextDecoder().decode(b);
-
-    async function readFile(path) {
-      const fd = await syscall('open', path, 'r');
-      let out = '';
-      while (true) {
-        const chunk = await syscall('read', fd, 1024);
-        if (chunk.length === 0) break;
-        out += decode(chunk);
-      }
-      await syscall('close', fd);
-      return out;
-    }
-
-    try {
-      const code = await readFile('/bin/login');
-      let m;
-      try { m = JSON.parse(await readFile('/bin/login.manifest.json')); } catch {}
-      await syscall('spawn', code, { syscalls: m ? m.syscalls : undefined });
-    } catch {
-      await syscall('write', STDERR_FD, encode('init: failed to launch login\n'));
-      return 1;
-    }
-    return 0;
-  }
-`;
-
 export const INIT_MANIFEST = JSON.stringify({
   name: 'init',
   syscalls: ['open', 'read', 'write', 'close', 'spawn']
 });
-
-export const REBOOT_SOURCE = `
-  async (syscall) => {
-    await syscall('reboot');
-    return 0;
-  }
-`;
 
 export const REBOOT_MANIFEST = JSON.stringify({
   name: 'reboot',
   syscalls: ['reboot']
 });
 
-export const SNAPSHOT_SOURCE = `
-  async (syscall, argv) => {
-    const STDERR_FD = 2;
-    const encode = (s) => new TextEncoder().encode(s);
-
-    if (argv.length < 2) {
-      await syscall('write', STDERR_FD, encode('usage: snapshot <save|load> <name>\n'));
-      return 1;
-    }
-
-    const action = argv[0];
-    const name = argv[1];
-
-    if (action === 'save') {
-      const snap = await syscall('snapshot');
-      await syscall('save_snapshot_named', name, snap);
-      return 0;
-    }
-
-    if (action === 'load') {
-      await syscall('load_snapshot_named', name);
-      await syscall('reboot');
-      return 0;
-    }
-
-    await syscall('write', STDERR_FD, encode('snapshot: unknown action\n'));
-    return 1;
-  }
-`;
-
 export const SNAPSHOT_MANIFEST = JSON.stringify({
   name: 'snapshot',
   syscalls: ['snapshot', 'save_snapshot_named', 'load_snapshot_named', 'reboot', 'write']
 });
+
+export const BUNDLED_APPS = new Map<string, string>([
+  ['nano', NANO_SOURCE],
+  ['browser', BROWSER_SOURCE],
+  ['ping', PING_SOURCE],
+  ['desktop', DESKTOP_SOURCE],
+  ['ls', LS_SOURCE],
+  ['mkdir', MKDIR_SOURCE],
+  ['rm', RM_SOURCE],
+  ['mv', MV_SOURCE],
+  ['ps', PS_SOURCE],
+  ['kill', KILL_SOURCE],
+  ['init', INIT_SOURCE],
+  ['login', LOGIN_SOURCE],
+  ['bash', BASH_SOURCE],
+  ['snapshot', SNAPSHOT_SOURCE],
+  ['ulimit', ULIMIT_SOURCE],
+]);
+
+export {
+  CAT_SOURCE,
+  ECHO_SOURCE,
+  NANO_SOURCE,
+  BROWSER_SOURCE,
+  PING_SOURCE,
+  DESKTOP_SOURCE,
+  LS_SOURCE,
+  MKDIR_SOURCE,
+  RM_SOURCE,
+  MV_SOURCE,
+  PS_SOURCE,
+  KILL_SOURCE,
+  SLEEP_SOURCE,
+  ULIMIT_SOURCE,
+  BASH_SOURCE,
+  LOGIN_SOURCE,
+  INIT_SOURCE,
+  REBOOT_SOURCE,
+  SNAPSHOT_SOURCE,
+};
 


### PR DESCRIPTION
## Summary
- move builtin app sources to `apps/bin-src`
- keep manifests in `core/fs/bin.ts` and import sources from new locations
- re-export `BUNDLED_APPS` from `core/fs/bin.ts`
- update `apps/index.ts` to use new exports

## Testing
- `pnpm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848574ef44883249b3c689b5fcba61b