### PR TITLE
Add syscall typings for app modules

### DIFF
--- a/apps/cli/programs/bash.ts
+++ b/apps/cli/programs/bash.ts
@@ -1,4 +1,4 @@
-import type { SyscallDispatcher } from "../../core/kernel/syscalls";
+import type { SyscallDispatcher } from "../../types/syscalls";
 
 export async function main(syscall: SyscallDispatcher, argv: string[]): Promise<number> {
     const STDOUT_FD = 1;

--- a/apps/cli/programs/browser.ts
+++ b/apps/cli/programs/browser.ts
@@ -1,4 +1,4 @@
-import type { SyscallDispatcher } from "../../core/kernel/syscalls";
+import type { SyscallDispatcher } from "../../types/syscalls";
 
 export async function main(syscall: SyscallDispatcher, argv: string[]): Promise<number> {
     const STDERR_FD = 2;

--- a/apps/cli/programs/cat.ts
+++ b/apps/cli/programs/cat.ts
@@ -1,4 +1,4 @@
-import type { SyscallDispatcher } from "../../core/kernel/syscalls";
+import type { SyscallDispatcher } from "../../types/syscalls";
 
 export async function main(syscall: SyscallDispatcher, argv: string[]): Promise<number> {
     const STDOUT_FD = 1;

--- a/apps/cli/programs/desktop.ts
+++ b/apps/cli/programs/desktop.ts
@@ -1,4 +1,4 @@
-import type { SyscallDispatcher } from "../../core/kernel/syscalls";
+import type { SyscallDispatcher } from "../../types/syscalls";
 
 export async function main(syscall: SyscallDispatcher, argv: string[]): Promise<number> {
     const STDERR_FD = 2;

--- a/apps/cli/programs/echo.ts
+++ b/apps/cli/programs/echo.ts
@@ -1,4 +1,4 @@
-import type { SyscallDispatcher } from "../../core/kernel/syscalls";
+import type { SyscallDispatcher } from "../../types/syscalls";
 
 export async function main(syscall: SyscallDispatcher, argv: string[]): Promise<number> {
     const STDOUT_FD = 1;

--- a/apps/cli/programs/init.ts
+++ b/apps/cli/programs/init.ts
@@ -1,4 +1,4 @@
-import type { SyscallDispatcher } from "../../core/kernel/syscalls";
+import type { SyscallDispatcher } from "../../types/syscalls";
 
 export async function main(syscall: SyscallDispatcher, _argv: string[]): Promise<number> {
     const STDERR_FD = 2;

--- a/apps/cli/programs/kill.ts
+++ b/apps/cli/programs/kill.ts
@@ -1,4 +1,4 @@
-import type { SyscallDispatcher } from "../../core/kernel/syscalls";
+import type { SyscallDispatcher } from "../../types/syscalls";
 
 export async function main(syscall: SyscallDispatcher, argv: string[]): Promise<number> {
     const pids: number[] = [];

--- a/apps/cli/programs/login.ts
+++ b/apps/cli/programs/login.ts
@@ -1,4 +1,4 @@
-import type { SyscallDispatcher } from "../../core/kernel/syscalls";
+import type { SyscallDispatcher } from "../../types/syscalls";
 
 export async function main(syscall: SyscallDispatcher, _argv: string[]): Promise<number> {
     const STDOUT_FD = 1;

--- a/apps/cli/programs/ls.ts
+++ b/apps/cli/programs/ls.ts
@@ -1,4 +1,4 @@
-import type { SyscallDispatcher } from "../../core/kernel/syscalls";
+import type { SyscallDispatcher } from "../../types/syscalls";
 
 export async function main(syscall: SyscallDispatcher, argv: string[]): Promise<number> {
     const STDOUT_FD = 1;

--- a/apps/cli/programs/mkdir.ts
+++ b/apps/cli/programs/mkdir.ts
@@ -1,4 +1,4 @@
-import type { SyscallDispatcher } from "../../core/kernel/syscalls";
+import type { SyscallDispatcher } from "../../types/syscalls";
 
 export async function main(syscall: SyscallDispatcher, argv: string[]): Promise<number> {
     const STDERR_FD = 2;

--- a/apps/cli/programs/mv.ts
+++ b/apps/cli/programs/mv.ts
@@ -1,4 +1,4 @@
-import type { SyscallDispatcher } from "../../core/kernel/syscalls";
+import type { SyscallDispatcher } from "../../types/syscalls";
 
 export async function main(syscall: SyscallDispatcher, argv: string[]): Promise<number> {
     const STDERR_FD = 2;

--- a/apps/cli/programs/nano.ts
+++ b/apps/cli/programs/nano.ts
@@ -1,4 +1,4 @@
-import type { SyscallDispatcher } from "../../core/kernel/syscalls";
+import type { SyscallDispatcher } from "../../types/syscalls";
 
 export async function main(syscall: SyscallDispatcher, argv: string[]): Promise<number> {
     const STDERR_FD = 2;

--- a/apps/cli/programs/ping.ts
+++ b/apps/cli/programs/ping.ts
@@ -1,4 +1,4 @@
-import type { SyscallDispatcher } from "../../core/kernel/syscalls";
+import type { SyscallDispatcher } from "../../types/syscalls";
 
 export async function main(syscall: SyscallDispatcher, argv: string[]): Promise<number> {
     const STDOUT_FD = 1;

--- a/apps/cli/programs/ps.ts
+++ b/apps/cli/programs/ps.ts
@@ -1,4 +1,4 @@
-import type { SyscallDispatcher } from "../../core/kernel/syscalls";
+import type { SyscallDispatcher } from "../../types/syscalls";
 
 export async function main(syscall: SyscallDispatcher, _argv: string[]): Promise<number> {
     const STDOUT_FD = 1;

--- a/apps/cli/programs/reboot.ts
+++ b/apps/cli/programs/reboot.ts
@@ -1,4 +1,4 @@
-import type { SyscallDispatcher } from "../../core/kernel/syscalls";
+import type { SyscallDispatcher } from "../../types/syscalls";
 
 export async function main(syscall: SyscallDispatcher): Promise<number> {
     await syscall('reboot');

--- a/apps/cli/programs/rm.ts
+++ b/apps/cli/programs/rm.ts
@@ -1,4 +1,4 @@
-import type { SyscallDispatcher } from "../../core/kernel/syscalls";
+import type { SyscallDispatcher } from "../../types/syscalls";
 
 export async function main(syscall: SyscallDispatcher, argv: string[]): Promise<number> {
     const STDERR_FD = 2;

--- a/apps/cli/programs/sleep.ts
+++ b/apps/cli/programs/sleep.ts
@@ -1,4 +1,4 @@
-import type { SyscallDispatcher } from "../../core/kernel/syscalls";
+import type { SyscallDispatcher } from "../../types/syscalls";
 
 export async function main(_syscall: SyscallDispatcher, argv: string[]): Promise<number> {
     const ms = parseInt(argv[0] || '1', 10) * 1000;

--- a/apps/cli/programs/snapshot.ts
+++ b/apps/cli/programs/snapshot.ts
@@ -1,4 +1,4 @@
-import type { SyscallDispatcher } from "../../core/kernel/syscalls";
+import type { SyscallDispatcher } from "../../types/syscalls";
 
 export async function main(syscall: SyscallDispatcher, argv: string[]): Promise<number> {
     const STDERR_FD = 2;

--- a/apps/cli/programs/ulimit.ts
+++ b/apps/cli/programs/ulimit.ts
@@ -1,4 +1,4 @@
-import type { SyscallDispatcher } from "../../core/kernel/syscalls";
+import type { SyscallDispatcher } from "../../types/syscalls";
 
 export async function main(syscall: SyscallDispatcher, argv: string[]): Promise<number> {
     const STDOUT_FD = 1;

--- a/apps/index.ts
+++ b/apps/index.ts
@@ -18,3 +18,4 @@ export * from "./cli/programs/snapshot";
 export * from "./cli/programs/ulimit";
 
 export { BUNDLED_APPS } from "../core/fs/generatedApps";
+export type { SyscallDispatcher } from "./types/syscalls";

--- a/apps/types/syscalls.d.ts
+++ b/apps/types/syscalls.d.ts
@@ -1,0 +1,31 @@
+import type { FileSystemNode, FileSystemSnapshot } from "../../core/fs";
+import type { ProcessID, FileDescriptor } from "../../core/kernel/process";
+import type { WindowOpts, ServiceHandler, Snapshot } from "../../core/kernel";
+
+export interface SyscallDispatcher {
+    (call: "open", path: string, flags: string): Promise<FileDescriptor>;
+    (call: "read", fd: FileDescriptor, length: number): Promise<Uint8Array>;
+    (call: "write", fd: FileDescriptor, data: Uint8Array): Promise<number>;
+    (call: "close", fd: FileDescriptor): Promise<number>;
+    (call: "spawn", code: string, opts?: any): Promise<ProcessID>;
+    (call: "listen", port: number, proto: string, cb: ServiceHandler): Promise<number>;
+    (call: "connect", ip: string, port: number): Promise<number>;
+    (call: "tcp_send" | "udp_send", sock: number, data: Uint8Array): Promise<number>;
+    (call: "draw", html: Uint8Array, opts: WindowOpts): Promise<number>;
+    (call: "mkdir", path: string, perms: number): Promise<number>;
+    (call: "readdir", path: string): Promise<FileSystemNode[]>;
+    (call: "unlink", path: string): Promise<number>;
+    (call: "rename", oldPath: string, newPath: string): Promise<number>;
+    (call: "mount", image: FileSystemSnapshot, path: string): Promise<number>;
+    (call: "unmount", path: string): Promise<number>;
+    (call: "set_quota", ms?: number, mem?: number): Promise<{ quotaMs: number; quotaMem: number }>;
+    (call: "kill", pid: ProcessID, sig?: number): Promise<number>;
+    (call: "snapshot"): Promise<Snapshot>;
+    (call: "save_snapshot" | "save_snapshot_named", name?: string): Promise<number>;
+    (call: "load_snapshot_named", name: string): Promise<number>;
+    (call: "ps"): Promise<Array<{ pid: number; argv?: string[]; exited?: boolean; cpuMs: number; memBytes: number; tty?: string }>>;
+    (call: "jobs"): Promise<Array<{ id: number; pids: ProcessID[]; status: string }>>;
+    (call: "reboot"): Promise<number>;
+    (call: string, ...args: any[]): Promise<any>;
+}
+export {};


### PR DESCRIPTION
## Summary
- define `SyscallDispatcher` and syscall signatures in `apps/types/syscalls.d.ts`
- re-export the type from `apps/index.ts`
- update all CLI programs to import the new interface

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684874dd1308832481764e89e9d48454