### PR TITLE
Bundle CLI app sources for filesystem

### DIFF
--- a/core/fs/index.ts
+++ b/core/fs/index.ts
@@ -11,6 +11,9 @@ import {
     BASH_SOURCE,
     REBOOT_SOURCE,
     SNAPSHOT_SOURCE,
+    SLEEP_SOURCE,
+} from "./generatedApps";
+import {
     CAT_MANIFEST,
     ECHO_MANIFEST,
     NANO_MANIFEST,
@@ -18,14 +21,13 @@ import {
     PING_MANIFEST,
     DESKTOP_MANIFEST,
     PS_MANIFEST,
-    SLEEP_SOURCE,
     SLEEP_MANIFEST,
     INIT_MANIFEST,
     LOGIN_MANIFEST,
     BASH_MANIFEST,
     REBOOT_MANIFEST,
     SNAPSHOT_MANIFEST,
-} from "./generatedApps";
+} from "./bin";
 import { createPersistHook, loadSnapshot } from "./sqlite";
 import type { AsyncFileSystem } from "./async";
 import { getParentPath, getBaseName } from "../utils/path";

--- a/core/fs/persistent.ts
+++ b/core/fs/persistent.ts
@@ -4,32 +4,34 @@ import type { FileSystemNode, FileSystemSnapshot, Permissions } from "./index";
 import { getParentPath, getBaseName } from "../utils/path";
 import {
     CAT_SOURCE,
-    CAT_MANIFEST,
     ECHO_SOURCE,
-    ECHO_MANIFEST,
     NANO_SOURCE,
-    NANO_MANIFEST,
     BROWSER_SOURCE,
-    BROWSER_MANIFEST,
     PING_SOURCE,
-    PING_MANIFEST,
     DESKTOP_SOURCE,
-    DESKTOP_MANIFEST,
     PS_SOURCE,
-    PS_MANIFEST,
     SLEEP_SOURCE,
-    SLEEP_MANIFEST,
     INIT_SOURCE,
-    INIT_MANIFEST,
     REBOOT_SOURCE,
-    REBOOT_MANIFEST,
     SNAPSHOT_SOURCE,
-    SNAPSHOT_MANIFEST,
     LOGIN_SOURCE,
-    LOGIN_MANIFEST,
     BASH_SOURCE,
-    BASH_MANIFEST,
 } from "./generatedApps";
+import {
+    CAT_MANIFEST,
+    ECHO_MANIFEST,
+    NANO_MANIFEST,
+    BROWSER_MANIFEST,
+    PING_MANIFEST,
+    DESKTOP_MANIFEST,
+    PS_MANIFEST,
+    SLEEP_MANIFEST,
+    INIT_MANIFEST,
+    REBOOT_MANIFEST,
+    SNAPSHOT_MANIFEST,
+    LOGIN_MANIFEST,
+    BASH_MANIFEST,
+} from "./bin";
 
 class LRUCache<K, V> {
     private map = new Map<K, V>();


### PR DESCRIPTION
## Summary
- load compiled CLI apps from `generatedApps.ts`
- keep manifest constants from `bin.ts`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68487811cbc48324b2b878efa444a596