### PR TITLE
Refactor UI architecture

### DIFF
--- a/ui/components/LoginPrompt.tsx
+++ b/ui/components/LoginPrompt.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { INPUT_STYLE, LOGIN_CONTAINER_STYLE } from "../constants";
 
 interface LoginPromptProps {
     onLogin: (user: string, pass: string) => void;
@@ -28,16 +29,11 @@ export const LoginPrompt: React.FC<LoginPromptProps> = ({ onLogin, error }) => {
     const inputProps = {
         autoFocus: true,
         onKeyDown: handleKey,
-        style: {
-            background: "black",
-            color: "#d4d4d4",
-            border: "none",
-            outline: "none",
-        } as React.CSSProperties,
+        style: INPUT_STYLE,
     };
 
     return (
-        <div style={{ color: "#d4d4d4", padding: "10px" }}>
+        <div style={LOGIN_CONTAINER_STYLE}>
             {error && <div style={{ color: "red" }}>{error}</div>}
             {step === "user" ? (
                 <label>

--- a/ui/components/Terminal.tsx
+++ b/ui/components/Terminal.tsx
@@ -1,0 +1,98 @@
+import React, {
+    forwardRef,
+    useEffect,
+    useImperativeHandle,
+    useRef,
+    useState,
+} from "react";
+import { XTerm } from "@pablo-lion/xterm-react";
+import { FitAddon } from "@xterm/addon-fit";
+import { Kernel } from "../../core/kernel";
+import { TERMINAL_THEME } from "../constants";
+
+export interface TerminalHandles {
+    fit: () => void;
+}
+
+interface TerminalProps {
+    kernel: Kernel;
+}
+
+const Terminal = forwardRef<TerminalHandles, TerminalProps>(({ kernel }, ref) => {
+    const xtermRef = useRef<XTerm>(null);
+    const fitAddonRef = useRef<FitAddon | null>(null);
+    const [commandLine, setCommandLine] = useState("");
+    const [isBusy, setIsBusy] = useState(false);
+
+    useEffect(() => {
+        const term = xtermRef.current?.terminal;
+        if (!term) return;
+
+        fitAddonRef.current = new FitAddon();
+        term.loadAddon(fitAddonRef.current);
+        setTimeout(() => fitAddonRef.current?.fit(), 1);
+
+        term.writeln("Welcome to Helios-OS Terminal");
+        term.write("$ ");
+
+        const originalLog = console.log;
+        const originalError = console.error;
+        const writeToTerminal = (data: any[], originalFunc: (...d: any[]) => void) => {
+            const message = data.join(" ");
+            const lines = message.split("\n");
+            lines.forEach((line, index) => {
+                term.write(line);
+                if (index < lines.length - 1) {
+                    term.write("\r\n");
+                }
+            });
+            originalFunc.apply(console, data);
+        };
+        console.log = (...args: any[]) => writeToTerminal(args, originalLog);
+        console.error = (...args: any[]) => writeToTerminal(args, originalError);
+
+        return () => {
+            console.log = originalLog;
+            console.error = originalError;
+        };
+    }, []);
+
+    const onData = async (data: string) => {
+        const term = xtermRef.current?.terminal;
+        if (!term || isBusy) return;
+        const code = data.charCodeAt(0);
+        if (code === 13) {
+            term.write("\r\n");
+            const command = commandLine.trim();
+            setCommandLine("");
+            const isBg = command.endsWith("&");
+            const cmd = isBg ? command.slice(0, -1).trim() : command;
+            if (cmd) {
+                if (!isBg) setIsBusy(true);
+                await kernel.spawn(cmd);
+                if (!isBg) setIsBusy(false);
+            }
+            term.write("$ ");
+        } else if (code === 127) {
+            if (commandLine.length > 0) {
+                term.write("\b \b");
+                setCommandLine((s) => s.slice(0, -1));
+            }
+        } else if (code >= 32) {
+            setCommandLine((s) => s + data);
+            term.write(data);
+        }
+    };
+
+    useImperativeHandle(ref, () => ({ fit: () => fitAddonRef.current?.fit() }));
+
+    return (
+        <XTerm
+            ref={xtermRef}
+            options={{ theme: TERMINAL_THEME, cursorBlink: true, convertEol: true }}
+            onData={onData}
+        />
+    );
+});
+
+export default Terminal;

--- a/ui/constants.ts
+++ b/ui/constants.ts
@@ -1,0 +1,25 @@
+export const COLORS = {
+    foreground: "#d4d4d4",
+    background: "#1e1e1e",
+};
+import type React from "react";
+import type { ITheme } from "@xterm/xterm";
+
+export const TERMINAL_THEME: ITheme = {
+    background: COLORS.background,
+    foreground: COLORS.foreground,
+    cursor: COLORS.foreground,
+    selectionBackground: "rgba(255, 255, 255, 0.3)",
+};
+
+export const LOGIN_CONTAINER_STYLE: React.CSSProperties = {
+    color: COLORS.foreground,
+    padding: "10px",
+};
+
+export const INPUT_STYLE: React.CSSProperties = {
+    background: "black",
+    color: COLORS.foreground,
+    border: "none",
+    outline: "none",
+};

--- a/ui/hooks/useKernel.ts
+++ b/ui/hooks/useKernel.ts
@@ -1,0 +1,52 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { Kernel } from "../../core/kernel";
+import { eventBus } from "../../core/utils/eventBus";
+
+export const useKernel = () => {
+    const kernelRef = useRef<Kernel | null>(null);
+    const bootStartRef = useRef<number>(0);
+    const [shellReady, setShellReady] = useState(false);
+
+    const startKernel = useCallback(async () => {
+        bootStartRef.current = performance.now();
+        const kernel = await Kernel.create();
+        kernelRef.current = kernel;
+        kernel.start().catch(console.error);
+    }, []);
+
+    useEffect(() => {
+        startKernel();
+        return () => {
+            kernelRef.current = null;
+        };
+    }, [startKernel]);
+
+    useEffect(() => {
+        const handler = () => {
+            kernelRef.current?.stop();
+        };
+        window.addEventListener("beforeunload", handler);
+        return () => window.removeEventListener("beforeunload", handler);
+    }, []);
+
+    useEffect(() => {
+        const handler = () => {
+            const dur = performance.now() - bootStartRef.current;
+            console.log(`Boot completed in ${Math.round(dur)} ms`);
+            setShellReady(true);
+        };
+        eventBus.on("boot.shellReady", handler);
+        return () => eventBus.off("boot.shellReady", handler);
+    }, []);
+
+    useEffect(() => {
+        const handler = () => {
+            setShellReady(false);
+            startKernel();
+        };
+        eventBus.on("system.reboot", handler);
+        return () => eventBus.off("system.reboot", handler);
+    }, [startKernel]);
+
+    return { kernel: kernelRef.current, shellReady };
+};

--- a/ui/index.tsx
+++ b/ui/index.tsx
@@ -1,109 +1,21 @@
-import React, { useEffect, useRef, useState, useCallback } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import ReactDOM from "react-dom/client";
-import { XTerm } from "@pablo-lion/xterm-react";
-import { ITheme } from "@xterm/xterm";
-import { FitAddon } from "@xterm/addon-fit";
 import "react-resizable/css/styles.css";
 import "@xterm/xterm/css/xterm.css";
 
-import { Kernel } from "../core/kernel";
-import {
-    WindowManager,
-    WindowManagerHandles,
-} from "./components/WindowManager";
+import { WindowManager, WindowManagerHandles } from "./components/WindowManager";
 import LoginPrompt from "./components/LoginPrompt";
+import Terminal, { TerminalHandles } from "./components/Terminal";
+import { useKernel } from "./hooks/useKernel";
 import { eventBus, type DrawPayload } from "../core/utils/eventBus";
-
-// A basic theme for the terminal
-const theme: ITheme = {
-    background: "#1e1e1e",
-    foreground: "#d4d4d4",
-    cursor: "#d4d4d4",
-    selectionBackground: "rgba(255, 255, 255, 0.3)",
-};
+import { COLORS } from "./constants";
 
 const App = () => {
-    const xtermRef = useRef<XTerm>(null);
-    const fitAddonRef = useRef<FitAddon | null>(null);
-    const kernelRef = useRef<Kernel | null>(null);
-    const bootStartRef = useRef<number>(0);
+    const { kernel, shellReady } = useKernel();
     const windowManagerRef = useRef<WindowManagerHandles>(null);
-    const [commandLine, setCommandLine] = useState("");
-    const [isBusy, setIsBusy] = useState(false);
-    const [shellReady, setShellReady] = useState(false);
+    const terminalRef = useRef<TerminalHandles>(null);
     const [loggedIn, setLoggedIn] = useState(false);
     const [loginError, setLoginError] = useState("");
-
-    const startKernel = useCallback(async () => {
-        bootStartRef.current = performance.now();
-        const kernel = await Kernel.create();
-        kernelRef.current = kernel;
-        kernel.start().catch(console.error);
-    }, []);
-
-    useEffect(() => {
-        startKernel();
-
-        return () => {
-            kernelRef.current = null;
-        };
-    }, [startKernel]);
-
-    useEffect(() => {
-        const handler = () => {
-            kernelRef.current?.stop();
-        };
-        window.addEventListener("beforeunload", handler);
-        return () => window.removeEventListener("beforeunload", handler);
-    }, []);
-
-    useEffect(() => {
-        if (!shellReady || !loggedIn) return;
-        let cleanup: (() => void) | undefined;
-
-        const term = xtermRef.current?.terminal;
-        if (term) {
-            fitAddonRef.current = new FitAddon();
-            term.loadAddon(fitAddonRef.current);
-
-            setTimeout(() => handleResize(), 1);
-
-            term.writeln("Welcome to Helios-OS Terminal");
-            term.write("$ ");
-
-            const originalLog = console.log;
-            const originalError = console.error;
-
-            const writeToTerminal = (
-                data: any[],
-                originalFunc: (...data: any[]) => void,
-            ) => {
-                const message = data.join(" ");
-                const lines = message.split("\n");
-                lines.forEach((line, index) => {
-                    term.write(line);
-                    if (index < lines.length - 1) {
-                        term.write("\r\n");
-                    }
-                });
-                originalFunc.apply(console, data);
-            };
-
-            console.log = (...args: any[]) =>
-                writeToTerminal(args, originalLog);
-            console.error = (...args: any[]) =>
-                writeToTerminal(args, originalError);
-
-            cleanup = () => {
-                console.log = originalLog;
-                console.error = originalError;
-            };
-        }
-
-        return () => {
-            cleanup?.();
-        };
-    }, [shellReady, loggedIn]);
 
     useEffect(() => {
         const handler = (payload: DrawPayload) => {
@@ -118,93 +30,38 @@ const App = () => {
                 content: payload.html,
             });
         };
-
         eventBus.on("desktop.createWindow", handler);
         return () => eventBus.off("desktop.createWindow", handler);
     }, []);
 
-    useEffect(() => {
-        const handler = () => {
-            const dur = performance.now() - bootStartRef.current;
-            console.log(`Boot completed in ${Math.round(dur)} ms`);
-            setShellReady(true);
-        };
-        eventBus.on("boot.shellReady", handler);
-        return () => eventBus.off("boot.shellReady", handler);
-    }, []);
-
-    useEffect(() => {
-        const handler = () => {
-            setShellReady(false);
-            setLoggedIn(false);
-            startKernel();
-        };
-        eventBus.on("system.reboot", handler);
-        return () => eventBus.off("system.reboot", handler);
-    }, [startKernel]);
-
     const handleResize = useCallback(() => {
-        fitAddonRef.current?.fit();
+        terminalRef.current?.fit();
     }, []);
 
-    const handleLogin = useCallback((user: string, pass: string) => {
-        if (user === "user" && pass === "password") {
-            kernelRef.current?.startNetworking();
-            setLoggedIn(true);
-            setLoginError("");
-        } else {
-            setLoginError("Invalid credentials");
-        }
-    }, []);
-
-    const onTerminalData = async (data: string) => {
-        const term = xtermRef.current?.terminal;
-        if (!term || isBusy || !shellReady || !loggedIn) return;
-
-        const code = data.charCodeAt(0);
-        if (code === 13) {
-            // Enter
-            term.write("\r\n");
-            const command = commandLine.trim();
-            setCommandLine("");
-
-            const isBg = command.endsWith("&");
-            const cmd = isBg ? command.slice(0, -1).trim() : command;
-
-            if (cmd) {
-                if (!isBg) setIsBusy(true);
-                await kernelRef.current?.spawn(cmd);
-                if (!isBg) setIsBusy(false);
+    const handleLogin = useCallback(
+        (user: string, pass: string) => {
+            if (user === "user" && pass === "password") {
+                kernel?.startNetworking();
+                setLoggedIn(true);
+                setLoginError("");
+            } else {
+                setLoginError("Invalid credentials");
             }
-            term.write("$ ");
-        } else if (code === 127) {
-            // Backspace
-            if (commandLine.length > 0) {
-                term.write("\b \b");
-                setCommandLine((s) => s.slice(0, -1));
-            }
-        } else if (code >= 32) {
-            // Printable characters
-            setCommandLine((s) => s + data);
-            term.write(data);
-        }
-    };
+        },
+        [kernel],
+    );
 
     return (
         <WindowManager ref={windowManagerRef} onResize={handleResize}>
             {!shellReady ? (
-                <div style={{ color: "#d4d4d4", padding: "10px" }}>
+                <div style={{ color: COLORS.foreground, padding: "10px" }}>
                     Booting...
                 </div>
             ) : !loggedIn ? (
                 <LoginPrompt onLogin={handleLogin} error={loginError} />
-            ) : (
-                <XTerm
-                    ref={xtermRef}
-                    options={{ theme, cursorBlink: true, convertEol: true }}
-                    onData={onTerminalData}
-                />
-            )}
+            ) : kernel ? (
+                <Terminal ref={terminalRef} kernel={kernel} />
+            ) : null}
         </WindowManager>
     );
 };


### PR DESCRIPTION
## Summary
- encapsulate terminal logic in `ui/components/Terminal.tsx`
- create `useKernel` hook for kernel lifecycle
- centralize theme values in `ui/constants.ts`
- simplify app composition using the new hook and terminal component
- update login prompt to use shared styles

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68487ac491348324bb6c549b3474d8c7