### PR TITLE
Refactor core tests with Vitest describe blocks

### DIFF
--- a/core/fs/index.test.ts
+++ b/core/fs/index.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { test } from "vitest";
+import { describe, it } from "vitest";
 import { InMemoryFileSystem } from "./index";
 
 function testSnapshot() {
@@ -38,9 +38,6 @@ function testUnmount() {
     console.log("Unmount test passed.");
 }
 
-test("snapshot load", testSnapshot);
-test("unmount", testUnmount);
-
 function testDirOps() {
     const fs = new InMemoryFileSystem();
     fs.createDirectory("/dir", 0o755);
@@ -57,8 +54,6 @@ function testDirOps() {
     console.log("Directory ops test passed.");
 }
 
-test("directory operations", testDirOps);
-
 function testFileDataPersistence() {
     const fs = new InMemoryFileSystem();
     const bytes = new Uint8Array([1, 2, 3, 4]);
@@ -73,4 +68,9 @@ function testFileDataPersistence() {
     console.log("File data persistence test passed.");
 }
 
-test("file data persistence", testFileDataPersistence);
+describe("InMemoryFileSystem", () => {
+    it("snapshot load", testSnapshot);
+    it("unmount", testUnmount);
+    it("directory operations", testDirOps);
+    it("file data persistence", testFileDataPersistence);
+});

--- a/core/fs/persistent.test.ts
+++ b/core/fs/persistent.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { test } from "vitest";
+import { describe, it, beforeEach, afterEach } from "vitest";
 import fs from "fs";
 import { PersistentFileSystem } from "./persistent";
 
@@ -257,8 +257,9 @@ function setup(dbPath: string) {
     };
 }
 
+let cleanup: () => void;
+
 async function run() {
-    const cleanup = setup("persistent_test.json");
     let fs1 = await PersistentFileSystem.load();
     await fs1.open("/persist.txt", "w");
     await fs1.write("/persist.txt", new TextEncoder().encode("hello"));
@@ -289,6 +290,16 @@ async function run() {
     cleanup();
 }
 
-test("persistent fs", async () => {
-    await run();
+describe("PersistentFileSystem", () => {
+    beforeEach(() => {
+        cleanup = setup("persistent_test.json");
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    it("persistent fs", async () => {
+        await run();
+    });
 });

--- a/core/kernel.test.ts
+++ b/core/kernel.test.ts
@@ -1,311 +1,273 @@
 import assert from "assert";
-import { test } from "vitest";
+import { describe, it, beforeEach, afterEach } from "vitest";
 import { createHash } from "node:crypto";
 import { Kernel } from "./kernel";
 import { InMemoryFileSystem } from "./fs";
 
-async function run() {
-    const kernel: any = new (Kernel as any)(new InMemoryFileSystem());
-    // Override runProcess to simulate asynchronous process running
-    let ran = false;
-    kernel.runProcess = async (pcb: any) => {
-        ran = true;
-        pcb.exited = true;
-    };
-    await kernel["syscall_spawn"]("dummy");
-    const startPromise = kernel.start();
-    // wait a tick then stop
-    setTimeout(() => kernel.stop(), 10);
-    await startPromise;
-    assert(ran, "process should run");
-    console.log("Kernel scheduler stop test passed.");
+describe("Kernel", () => {
+    let kernel: any;
 
-    const img = new InMemoryFileSystem();
-    img.createFile("/foo.txt", "bar", 0o644);
-    const snap = img.getSnapshot();
-    await kernel["syscall_mount"](snap, "/mnt");
-    assert(kernel["state"].fs.getNode("/mnt/foo.txt"), "file mounted");
-    await kernel["syscall_unmount"]("/mnt");
-    assert(!kernel["state"].fs.getNode("/mnt/foo.txt"), "file unmounted");
-    console.log("Kernel mount/unmount test passed.");
-
-    const pid = kernel["createProcess"]();
-    const pcb = kernel["state"].processes.get(pid);
-    try {
-        await kernel["syscall_open"](pcb, "/", "r");
-        assert.fail("opening directory should throw");
-    } catch (e: any) {
-        assert(e.message.includes("EISDIR"), "EISDIR error expected");
-        console.log("Kernel open directory test passed.");
-    }
-
-    const list = kernel["syscall_ps"]();
-    assert(
-        Array.isArray(list) && list.length > 0,
-        "ps should return processes",
-    );
-    console.log("Kernel ps syscall test passed.");
-
-    // ps should report cpu/mem usage and tty information
-    const psKernel: any = new (Kernel as any)(new InMemoryFileSystem());
-    let runs = 0;
-    psKernel.runProcess = async (pcb: any) => {
-        pcb.exitCode = 0;
-        pcb.cpuMs += 5;
-        pcb.memBytes += 1024;
-        runs++;
-        if (runs >= 2) pcb.exited = true;
-    };
-    const psPid = await psKernel["syscall_spawn"]("dummy", {
-        tty: "/dev/tty1",
+    beforeEach(() => {
+        kernel = new (Kernel as any)(new InMemoryFileSystem());
     });
-    const psPcb = psKernel["state"].processes.get(psPid);
-    await psKernel.runProcess(psPcb);
-    await psKernel.runProcess(psPcb);
-    const psList = psKernel["syscall_ps"]();
-    const proc = psList.find((p: any) => p.pid === psPid);
-    assert(
-        proc &&
-            proc.cpuMs === 10 &&
-            proc.memBytes === 2048 &&
-            proc.tty === "/dev/tty1",
-        "ps should return accumulated cpu/mem and tty",
-    );
-    console.log("Kernel ps resource accumulation test passed.");
 
-    // regression: syscall permissions survive snapshot/restore
-    const permKernel: any = new (Kernel as any)(new InMemoryFileSystem());
-    const pid2 = await permKernel["syscall_spawn"]("dummy", {
-        syscalls: ["ps"],
+    afterEach(async () => {
+        await kernel.stop();
     });
-    const permSnap = permKernel.snapshot();
-    const restored: any = await (Kernel as any).restore(permSnap);
-    const pcb2 = restored["state"].processes.get(pid2);
-    assert(
-        pcb2.allowedSyscalls instanceof Set && pcb2.allowedSyscalls.has("ps"),
-        "permissions should persist after restore",
-    );
-    console.log("Kernel syscall permissions restore test passed.");
 
-    // open descriptors survive snapshot/restore
-    const fdKernel: any = new (Kernel as any)(new InMemoryFileSystem());
-    fdKernel["state"].fs.createDirectory("/tmp", 0o755);
-    fdKernel["state"].fs.createFile("/tmp/foo.txt", "hello", 0o644);
-    const pid3 = fdKernel["createProcess"]();
-    const pcb3 = fdKernel["state"].processes.get(pid3);
-    const fd = await fdKernel["syscall_open"](pcb3, "/tmp/foo.txt", "r");
-    const snapFd = fdKernel.snapshot();
-    const restoredFd: any = await (Kernel as any).restore(snapFd);
-    const pcbRestored = restoredFd["state"].processes.get(pid3);
-    const data = await restoredFd["syscall_read"](pcbRestored, fd, 5);
-    assert(
-        new TextDecoder().decode(data) === "hello",
-        "open descriptor restored",
-    );
-    console.log("Kernel fd restore test passed.");
+    it("scheduler stop", async () => {
+        let ran = false;
+        kernel.runProcess = async (pcb: any) => {
+            ran = true;
+            pcb.exited = true;
+        };
+        await kernel["syscall_spawn"]("dummy");
+        const startPromise = kernel.start();
+        setTimeout(() => kernel.stop(), 10);
+        await startPromise;
+        assert(ran, "process should run");
+    });
 
-    // scheduler timeslicing requeues running process
-    globalThis.window = {} as any;
-    globalThis.window.crypto = {
-        getRandomValues: (arr: Uint32Array) =>
-            require("crypto").randomFillSync(arr),
-    };
-    const { mockIPC, clearMocks } = await import("@tauri-apps/api/mocks");
-    let slices = 0;
-    mockIPC((_cmd, _args) => {
-        slices++;
-        if (slices < 3) {
-            return { running: true, cpu_ms: 1, mem_bytes: 0 };
+    it("mount and unmount", async () => {
+        const img = new InMemoryFileSystem();
+        img.createFile("/foo.txt", "bar", 0o644);
+        const snap = img.getSnapshot();
+        await kernel["syscall_mount"](snap, "/mnt");
+        assert(kernel["state"].fs.getNode("/mnt/foo.txt"), "file mounted");
+        await kernel["syscall_unmount"]("/mnt");
+        assert(!kernel["state"].fs.getNode("/mnt/foo.txt"), "file unmounted");
+    });
+
+    it("opening directory throws EISDIR", async () => {
+        const pid = kernel["createProcess"]();
+        const pcb = kernel["state"].processes.get(pid);
+        try {
+            await kernel["syscall_open"](pcb, "/", "r");
+            assert.fail("opening directory should throw");
+        } catch (e: any) {
+            assert(e.message.includes("EISDIR"), "EISDIR error expected");
         }
-        return { running: false, exit_code: 0, cpu_ms: 1, mem_bytes: 0 };
     });
-    const schedKernel: any = new (Kernel as any)(new InMemoryFileSystem());
-    await schedKernel["syscall_spawn"]("dummy", { quotaMs: 1 });
-    const schedStart = schedKernel.start();
-    setTimeout(() => schedKernel.stop(), 10);
-    await schedStart;
-    clearMocks();
-    // @ts-ignore
-    delete globalThis.window;
-    assert(slices >= 3, "process should be requeued multiple times");
-    console.log("Kernel scheduler timeslice test passed.");
 
-    // persistent isolate accumulates resources across slices
-    globalThis.window = {} as any;
-    globalThis.window.crypto = {
-        getRandomValues: (arr: Uint32Array) =>
-            require("crypto").randomFillSync(arr),
-    };
-    const { mockIPC: mockPersist, clearMocks: clearPersist } = await import(
-        "@tauri-apps/api/mocks"
-    );
-    const calls: any[] = [];
-    mockPersist((cmd, args) => {
-        if (cmd === "run_isolate_slice") {
-            calls.push(args);
-            if (calls.length === 1) {
-                return { running: true, cpu_ms: 2, mem_bytes: 100 };
-            }
-            return { running: false, exit_code: 0, cpu_ms: 3, mem_bytes: 150 };
-        }
-        return undefined;
+    it("ps syscall returns processes", () => {
+        const list = kernel["syscall_ps"]();
+        assert(Array.isArray(list) && list.length > 0, "ps should return processes");
     });
-    const persistKernel: any = new (Kernel as any)(new InMemoryFileSystem());
-    const persistPid = await persistKernel["syscall_spawn"]("dummy", {
-        quotaMs: 1,
-    });
-    const persistPcb = persistKernel["state"].processes.get(persistPid);
-    await persistKernel["runProcess"](persistPcb);
-    await persistKernel["runProcess"](persistPcb);
-    clearPersist();
-    // @ts-ignore
-    delete globalThis.window;
-    assert.strictEqual(calls.length, 2, "host called twice");
-    assert("code" in calls[0], "first slice should include code");
-    assert(!("code" in calls[1]), "subsequent slice should omit code");
-    assert.strictEqual(persistPcb.cpuMs, 5, "CPU time accumulates");
-    assert.strictEqual(persistPcb.memBytes, 250, "memory usage accumulates");
-    assert.strictEqual(persistPcb.exited, true, "process should exit");
-    console.log("Kernel persistent isolate accumulation test passed.");
 
-    // job table management
-    const jobKernel: any = new (Kernel as any)(new InMemoryFileSystem());
-    const jid = jobKernel.registerJob([123], "sleep 1");
-    let jobList = jobKernel["syscall_jobs"]();
-    assert.strictEqual(jobList.length, 1, "job should register");
-    assert.strictEqual(jobList[0].id, jid, "job id matches");
-    jobKernel.updateJobStatus(jid, "Done");
-    jobList = jobKernel["syscall_jobs"]();
-    assert.strictEqual(jobList[0].status, "Done", "status updates");
-    jobKernel.removeJob(jid);
-    assert.strictEqual(jobKernel["syscall_jobs"]().length, 0, "job removal");
-    console.log("Kernel job table test passed.");
-
-    // snapshot save/load preserves fs hash and window list
-    const snapKernel: any = new (Kernel as any)(new InMemoryFileSystem());
-    snapKernel["state"].fs.createDirectory("/snap", 0o755);
-    snapKernel["state"].fs.createFile("/snap/test.txt", "data", 0o644);
-    snapKernel["syscall_draw"](new TextEncoder().encode("<p>hi</p>"), {
-        title: "t",
-    });
-    const hash1 = createHash("sha256")
-        .update(JSON.stringify(snapKernel["state"].fs.getSnapshot()))
-        .digest("hex");
-    const snapshot = snapKernel.snapshot();
-    const restoredSnap: any = await (Kernel as any).restore(snapshot);
-    const hash2 = createHash("sha256")
-        .update(JSON.stringify(restoredSnap["state"].fs.getSnapshot()))
-        .digest("hex");
-    assert.strictEqual(
-        hash1,
-        hash2,
-        "filesystem hash should match after restore",
-    );
-    assert.deepStrictEqual(
-        restoredSnap["state"].windows,
-        snapKernel["state"].windows,
-        "windows should restore identically",
-    );
-    console.log("Kernel snapshot save/load test passed.");
-
-    // /proc filesystem
-    const procKernel: any = new (Kernel as any)(new InMemoryFileSystem());
-    const procPid = procKernel["createProcess"]();
-    const procPcb = procKernel["state"].processes.get(procPid);
-    procKernel["state"].fs.createDirectory("/tmp", 0o755);
-    procKernel["state"].fs.createFile("/tmp/foo.txt", "bar", 0o644);
-    const f = await procKernel["syscall_open"](procPcb, "/tmp/foo.txt", "r");
-    const fdList = await procKernel["syscall_readdir"](`/proc/${procPid}/fd`);
-    assert(
-        fdList.some((n: any) => n.path === `/proc/${procPid}/fd/${f}`),
-        "/proc/<pid>/fd lists open descriptors",
-    );
-    const sfd = await procKernel["syscall_open"](
-        procPcb,
-        `/proc/${procPid}/status`,
-        "r",
-    );
-    const stat = await procKernel["syscall_read"](procPcb, sfd, 1024);
-    const text = new TextDecoder().decode(stat);
-    assert(
-        text.includes("pid\t" + procPid) || text.includes("pid:\t" + procPid),
-        "status file readable",
-    );
-    console.log("/proc filesystem test passed.");
-
-    try {
-        await procKernel["syscall_open"](
-            procPcb,
-            `/proc/${procPid + 1}/status`,
-            "r",
-        );
-        assert.fail("opening nonexistent /proc entry should throw");
-    } catch (e: any) {
+    it("ps resource accumulation", async () => {
+        const psKernel: any = new (Kernel as any)(new InMemoryFileSystem());
+        let runs = 0;
+        psKernel.runProcess = async (pcb: any) => {
+            pcb.exitCode = 0;
+            pcb.cpuMs += 5;
+            pcb.memBytes += 1024;
+            runs++;
+            if (runs >= 2) pcb.exited = true;
+        };
+        const psPid = await psKernel["syscall_spawn"]("dummy", { tty: "/dev/tty1" });
+        const psPcb = psKernel["state"].processes.get(psPid);
+        await psKernel.runProcess(psPcb);
+        await psKernel.runProcess(psPcb);
+        const psList = psKernel["syscall_ps"]();
+        const proc = psList.find((p: any) => p.pid === psPid);
         assert(
-            e.message.includes("ENOENT"),
-            "ENOENT expected for missing process",
+            proc &&
+                proc.cpuMs === 10 &&
+                proc.memBytes === 2048 &&
+                proc.tty === "/dev/tty1",
+            "ps should return accumulated cpu/mem and tty",
         );
-    }
-
-    try {
-        await procKernel["syscall_open"](
-            procPcb,
-            `/proc/${procPid}/fd/${procPcb.nextFd}`,
-            "r",
-        );
-        assert.fail("opening nonexistent fd should throw");
-    } catch (e: any) {
-        assert(e.message.includes("ENOENT"), "ENOENT expected for missing fd");
-    }
-    console.log("Kernel /proc ENOENT tests passed.");
-
-    // kill syscall terminates a process
-    const killKernel: any = new (Kernel as any)(new InMemoryFileSystem());
-    const killPid = await killKernel["syscall_spawn"]("dummy");
-    const killPcb = killKernel["state"].processes.get(killPid);
-    const killRes = killKernel["syscall_kill"](killPid, 9);
-    assert.strictEqual(killRes, 0, "kill should return 0");
-    assert.strictEqual(killPcb.exited, true, "process should be marked exited");
-    console.log("Kernel kill syscall test passed.");
-
-    // init process cannot be killed
-    const initKernel: any = new (Kernel as any)(new InMemoryFileSystem());
-    const initPid = await initKernel["syscall_spawn"]("dummy");
-    initKernel["initPid"] = initPid;
-    const initRes = initKernel["syscall_kill"](initPid, 9);
-    assert.strictEqual(initRes, -1, "killing init should fail");
-    const initPcb = initKernel["state"].processes.get(initPid);
-    assert.strictEqual(initPcb.exited, false, "init should remain running");
-    console.log("Kernel init kill protection test passed.");
-
-    // memory quota enforcement
-    globalThis.window = {} as any;
-    globalThis.window.crypto = {
-        getRandomValues: (arr: Uint32Array) =>
-            require("crypto").randomFillSync(arr),
-    };
-    const { mockIPC: mockQuota, clearMocks: clearQuota } = await import(
-        "@tauri-apps/api/mocks"
-    );
-    mockQuota(() => ({ running: true, cpu_ms: 1, mem_bytes: 2048 }));
-    const quotaKernel: any = new (Kernel as any)(new InMemoryFileSystem());
-    const quotaPid = await quotaKernel["syscall_spawn"]("dummy", {
-        quotaMs: 1,
     });
-    const quotaPcb = quotaKernel["state"].processes.get(quotaPid);
-    quotaKernel["syscall_set_quota"](quotaPcb, undefined, 1024);
-    await quotaKernel["runProcess"](quotaPcb);
-    clearQuota();
-    // @ts-ignore
-    delete globalThis.window;
-    assert.strictEqual(
-        quotaPcb.exited,
-        true,
-        "process should exit when exceeding memory quota",
-    );
-    console.log("Kernel memory quota enforcement test passed.");
-}
 
-test("kernel", async () => {
-    await run();
+    it("syscall permissions persist after restore", async () => {
+        const permKernel: any = new (Kernel as any)(new InMemoryFileSystem());
+        const pid2 = await permKernel["syscall_spawn"]("dummy", { syscalls: ["ps"] });
+        const permSnap = permKernel.snapshot();
+        const restored: any = await (Kernel as any).restore(permSnap);
+        const pcb2 = restored["state"].processes.get(pid2);
+        assert(
+            pcb2.allowedSyscalls instanceof Set && pcb2.allowedSyscalls.has("ps"),
+            "permissions should persist after restore",
+        );
+    });
+
+    it("open descriptors survive snapshot restore", async () => {
+        const fdKernel: any = new (Kernel as any)(new InMemoryFileSystem());
+        fdKernel["state"].fs.createDirectory("/tmp", 0o755);
+        fdKernel["state"].fs.createFile("/tmp/foo.txt", "hello", 0o644);
+        const pid3 = fdKernel["createProcess"]();
+        const pcb3 = fdKernel["state"].processes.get(pid3);
+        const fd = await fdKernel["syscall_open"](pcb3, "/tmp/foo.txt", "r");
+        const snapFd = fdKernel.snapshot();
+        const restoredFd: any = await (Kernel as any).restore(snapFd);
+        const pcbRestored = restoredFd["state"].processes.get(pid3);
+        const data = await restoredFd["syscall_read"](pcbRestored, fd, 5);
+        assert(new TextDecoder().decode(data) === "hello", "open descriptor restored");
+    });
+
+    it("scheduler timeslice requeues running process", async () => {
+        globalThis.window = {} as any;
+        globalThis.window.crypto = {
+            getRandomValues: (arr: Uint32Array) => require("crypto").randomFillSync(arr),
+        };
+        const { mockIPC, clearMocks } = await import("@tauri-apps/api/mocks");
+        let slices = 0;
+        mockIPC((_cmd, _args) => {
+            slices++;
+            if (slices < 3) {
+                return { running: true, cpu_ms: 1, mem_bytes: 0 };
+            }
+            return { running: false, exit_code: 0, cpu_ms: 1, mem_bytes: 0 };
+        });
+        const schedKernel: any = new (Kernel as any)(new InMemoryFileSystem());
+        await schedKernel["syscall_spawn"]("dummy", { quotaMs: 1 });
+        const schedStart = schedKernel.start();
+        setTimeout(() => schedKernel.stop(), 10);
+        await schedStart;
+        clearMocks();
+        // @ts-ignore
+        delete globalThis.window;
+        assert(slices >= 3, "process should be requeued multiple times");
+    });
+
+    it("persistent isolate accumulates resources", async () => {
+        globalThis.window = {} as any;
+        globalThis.window.crypto = {
+            getRandomValues: (arr: Uint32Array) => require("crypto").randomFillSync(arr),
+        };
+        const { mockIPC: mockPersist, clearMocks: clearPersist } = await import("@tauri-apps/api/mocks");
+        const calls: any[] = [];
+        mockPersist((cmd, args) => {
+            if (cmd === "run_isolate_slice") {
+                calls.push(args);
+                if (calls.length === 1) {
+                    return { running: true, cpu_ms: 2, mem_bytes: 100 };
+                }
+                return { running: false, exit_code: 0, cpu_ms: 3, mem_bytes: 150 };
+            }
+            return undefined;
+        });
+        const persistKernel: any = new (Kernel as any)(new InMemoryFileSystem());
+        const persistPid = await persistKernel["syscall_spawn"]("dummy", { quotaMs: 1 });
+        const persistPcb = persistKernel["state"].processes.get(persistPid);
+        await persistKernel["runProcess"](persistPcb);
+        await persistKernel["runProcess"](persistPcb);
+        clearPersist();
+        // @ts-ignore
+        delete globalThis.window;
+        assert.strictEqual(calls.length, 2, "host called twice");
+        assert("code" in calls[0], "first slice should include code");
+        assert(!("code" in calls[1]), "subsequent slice should omit code");
+        assert.strictEqual(persistPcb.cpuMs, 5, "CPU time accumulates");
+        assert.strictEqual(persistPcb.memBytes, 250, "memory usage accumulates");
+        assert.strictEqual(persistPcb.exited, true, "process should exit");
+    });
+
+    it("job table management", () => {
+        const jobKernel: any = new (Kernel as any)(new InMemoryFileSystem());
+        const jid = jobKernel.registerJob([123], "sleep 1");
+        let jobList = jobKernel["syscall_jobs"]();
+        assert.strictEqual(jobList.length, 1, "job should register");
+        assert.strictEqual(jobList[0].id, jid, "job id matches");
+        jobKernel.updateJobStatus(jid, "Done");
+        jobList = jobKernel["syscall_jobs"]();
+        assert.strictEqual(jobList[0].status, "Done", "status updates");
+        jobKernel.removeJob(jid);
+        assert.strictEqual(jobKernel["syscall_jobs"]().length, 0, "job removal");
+    });
+
+    it("snapshot save/load", async () => {
+        const snapKernel: any = new (Kernel as any)(new InMemoryFileSystem());
+        snapKernel["state"].fs.createDirectory("/snap", 0o755);
+        snapKernel["state"].fs.createFile("/snap/test.txt", "data", 0o644);
+        snapKernel["syscall_draw"](new TextEncoder().encode("<p>hi</p>"), { title: "t" });
+        const hash1 = createHash("sha256")
+            .update(JSON.stringify(snapKernel["state"].fs.getSnapshot()))
+            .digest("hex");
+        const snapshot = snapKernel.snapshot();
+        const restoredSnap: any = await (Kernel as any).restore(snapshot);
+        const hash2 = createHash("sha256")
+            .update(JSON.stringify(restoredSnap["state"].fs.getSnapshot()))
+            .digest("hex");
+        assert.strictEqual(hash1, hash2, "filesystem hash should match after restore");
+        assert.deepStrictEqual(
+            restoredSnap["state"].windows,
+            snapKernel["state"].windows,
+            "windows should restore identically",
+        );
+    });
+
+    it("/proc filesystem", async () => {
+        const procKernel: any = new (Kernel as any)(new InMemoryFileSystem());
+        const procPid = procKernel["createProcess"]();
+        const procPcb = procKernel["state"].processes.get(procPid);
+        procKernel["state"].fs.createDirectory("/tmp", 0o755);
+        procKernel["state"].fs.createFile("/tmp/foo.txt", "bar", 0o644);
+        const f = await procKernel["syscall_open"](procPcb, "/tmp/foo.txt", "r");
+        const fdList = await procKernel["syscall_readdir"](`/proc/${procPid}/fd`);
+        assert(
+            fdList.some((n: any) => n.path === `/proc/${procPid}/fd/${f}`),
+            "/proc/<pid>/fd lists open descriptors",
+        );
+        const sfd = await procKernel["syscall_open"](procPcb, `/proc/${procPid}/status`, "r");
+        const stat = await procKernel["syscall_read"](procPcb, sfd, 1024);
+        const text = new TextDecoder().decode(stat);
+        assert(
+            text.includes("pid\t" + procPid) || text.includes("pid:\t" + procPid),
+            "status file readable",
+        );
+        try {
+            await procKernel["syscall_open"](procPcb, `/proc/${procPid + 1}/status`, "r");
+            assert.fail("opening nonexistent /proc entry should throw");
+        } catch (e: any) {
+            assert(e.message.includes("ENOENT"), "ENOENT expected for missing process");
+        }
+        try {
+            await procKernel["syscall_open"](procPcb, `/proc/${procPid}/fd/${procPcb.nextFd}`, "r");
+            assert.fail("opening nonexistent fd should throw");
+        } catch (e: any) {
+            assert(e.message.includes("ENOENT"), "ENOENT expected for missing fd");
+        }
+    });
+
+    it("kill syscall terminates a process", async () => {
+        const killKernel: any = new (Kernel as any)(new InMemoryFileSystem());
+        const killPid = await killKernel["syscall_spawn"]("dummy");
+        const killPcb = killKernel["state"].processes.get(killPid);
+        const killRes = killKernel["syscall_kill"](killPid, 9);
+        assert.strictEqual(killRes, 0, "kill should return 0");
+        assert.strictEqual(killPcb.exited, true, "process should be marked exited");
+    });
+
+    it("init process cannot be killed", async () => {
+        const initKernel: any = new (Kernel as any)(new InMemoryFileSystem());
+        const initPid = await initKernel["syscall_spawn"]("dummy");
+        initKernel["initPid"] = initPid;
+        const initRes = initKernel["syscall_kill"](initPid, 9);
+        assert.strictEqual(initRes, -1, "killing init should fail");
+        const initPcb = initKernel["state"].processes.get(initPid);
+        assert.strictEqual(initPcb.exited, false, "init should remain running");
+    });
+
+    it("memory quota enforcement", async () => {
+        globalThis.window = {} as any;
+        globalThis.window.crypto = {
+            getRandomValues: (arr: Uint32Array) => require("crypto").randomFillSync(arr),
+        };
+        const { mockIPC: mockQuota, clearMocks: clearQuota } = await import("@tauri-apps/api/mocks");
+        mockQuota(() => ({ running: true, cpu_ms: 1, mem_bytes: 2048 }));
+        const quotaKernel: any = new (Kernel as any)(new InMemoryFileSystem());
+        const quotaPid = await quotaKernel["syscall_spawn"]("dummy", { quotaMs: 1 });
+        const quotaPcb = quotaKernel["state"].processes.get(quotaPid);
+        quotaKernel["syscall_set_quota"](quotaPcb, undefined, 1024);
+        await quotaKernel["runProcess"](quotaPcb);
+        clearQuota();
+        // @ts-ignore
+        delete globalThis.window;
+        assert.strictEqual(
+            quotaPcb.exited,
+            true,
+            "process should exit when exceeding memory quota",
+        );
+    });
 });

--- a/core/net/index.test.ts
+++ b/core/net/index.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { test } from "vitest";
+import { describe, it } from "vitest";
 import { TCP } from "./tcp";
 import { UDP } from "./udp";
 import { NIC } from "./nic";
@@ -94,10 +94,12 @@ async function testTcpEcho() {
     console.log("TCP send response test passed.");
 }
 
-test("TCP listen/connect", testTcp);
-test("UDP handler source info", testUdp);
-test("Switch forwarding", testSwitch);
-test("Router forward", testRouter);
-test("TCP send response", async () => {
-    await testTcpEcho();
+describe("Networking", () => {
+    it("TCP listen/connect", testTcp);
+    it("UDP handler source info", testUdp);
+    it("Switch forwarding", testSwitch);
+    it("Router forward", testRouter);
+    it("TCP send response", async () => {
+        await testTcpEcho();
+    });
 });

--- a/core/snapshot.test.ts
+++ b/core/snapshot.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { test } from "vitest";
+import { describe, it } from "vitest";
 import { createHash } from "node:crypto";
 import { Kernel } from "./kernel";
 import { InMemoryFileSystem } from "./fs";
@@ -8,37 +8,35 @@ function checksum(obj: any): string {
     return createHash("sha256").update(JSON.stringify(obj)).digest("hex");
 }
 
-async function run() {
-    const kernel: any = new (Kernel as any)(new InMemoryFileSystem());
-    const snap1 = kernel.snapshot();
-    const restored1: any = await (Kernel as any).restore(snap1);
-    const snap2 = restored1.snapshot();
-    const restored2: any = await (Kernel as any).restore(snap2);
-    const snap3 = restored2.snapshot();
-    assert.strictEqual(
-        checksum(snap2),
-        checksum(snap3),
-        "snapshot checksums must match",
-    );
-    console.log("Snapshot deterministic load test passed.");
+describe("Kernel snapshots", () => {
+    it("deterministic load", async () => {
+        const kernel: any = new (Kernel as any)(new InMemoryFileSystem());
+        const snap1 = kernel.snapshot();
+        const restored1: any = await (Kernel as any).restore(snap1);
+        const snap2 = restored1.snapshot();
+        const restored2: any = await (Kernel as any).restore(snap2);
+        const snap3 = restored2.snapshot();
+        assert.strictEqual(
+            checksum(snap2),
+            checksum(snap3),
+            "snapshot checksums must match",
+        );
+    });
 
-    const netKernel: any = new (Kernel as any)(new InMemoryFileSystem());
-    netKernel.startNetworking();
-    (await import("./services")).startHttpd(netKernel, { port: 8080 });
-    const sock = netKernel["state"].tcp.connect("127.0.0.1", 8080);
-    await netKernel["state"].tcp.send(sock, new Uint8Array([1, 2, 3]));
-    const netSnap1 = netKernel.snapshot();
-    const netRestored: any = await (Kernel as any).restore(netSnap1);
-    netRestored.startNetworking();
-    const netSnap2 = netRestored.snapshot();
-    assert.strictEqual(
-        checksum(netSnap1),
-        checksum(netSnap2),
-        "networked snapshot checksums must match",
-    );
-    console.log("Networked snapshot restore test passed.");
-}
-
-test("snapshot", async () => {
-    await run();
+    it("network snapshot restore", async () => {
+        const netKernel: any = new (Kernel as any)(new InMemoryFileSystem());
+        netKernel.startNetworking();
+        (await import("./services")).startHttpd(netKernel, { port: 8080 });
+        const sock = netKernel["state"].tcp.connect("127.0.0.1", 8080);
+        await netKernel["state"].tcp.send(sock, new Uint8Array([1, 2, 3]));
+        const netSnap1 = netKernel.snapshot();
+        const netRestored: any = await (Kernel as any).restore(netSnap1);
+        netRestored.startNetworking();
+        const netSnap2 = netRestored.snapshot();
+        assert.strictEqual(
+            checksum(netSnap1),
+            checksum(netSnap2),
+            "networked snapshot checksums must match",
+        );
+    });
 });


### PR DESCRIPTION
## Summary
- convert tests under `core/` to use `describe()` and `it()`
- use `beforeEach`/`afterEach` hooks when creating a persistent fs
- drop old `run()` wrappers and keep original assertions

## Testing
- `pnpm test` *(fails: `pnpm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68487e73bbc0832496241c07cf05a8e6