### PR TITLE
Update testing docs to mention Vitest

### DIFF
--- a/docs/kernel_mvp.md
+++ b/docs/kernel_mvp.md
@@ -141,7 +141,7 @@ The UI component sends entered lines to `kernel.spawn()` and prints output when 
 5. write & read: `echo hi > /tmp/foo` then `cat /tmp/foo` prints `hi`.
 6. Process cleanup: repeated `echo` does not leak PIDs or FDs.
 
-A Jest suite can automate these checks by invoking kernel APIs directly.
+A Vitest suite can automate these checks by invoking kernel APIs directly.
 
 ## Next Steps
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -23,10 +23,13 @@ This project uses `pnpm` for managing Node dependencies and scripts.
     pnpm build:release
     ```
 
-4. Run the test suite before committing:
+4. Run the test suite with **Vitest** before committing:
 
     ```sh
     pnpm test
     ```
+
+    Vitest compiles the TypeScript sources automatically, so no esbuild step is
+    required.
 
 The project enforces TypeScript strict mode. Use four spaces for indentation and ensure files end with a trailing newline.


### PR DESCRIPTION
## Summary
- update workflow instructions for running tests with Vitest
- mention Vitest instead of Jest in the kernel MVP docs

## Testing
- `pnpm test` *(fails: ps syscall returns processes)*

------
https://chatgpt.com/codex/tasks/task_e_6848807bee308324a950e00162a6f448