### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+    push:
+        branches: ["**"]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: pnpm/action-setup@v2
+              with:
+                  version: 8
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: 18
+                  cache: 'pnpm'
+            - uses: actions/cache@v3
+              with:
+                  path: ~/.pnpm-store
+                  key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+                  restore-keys: |
+                      ${{ runner.os }}-pnpm-store-
+            - run: pnpm i
+            - run: pnpm build
+            - run: pnpm test


### PR DESCRIPTION
## Summary
- run tests and build via GitHub Actions
- cache `~/.pnpm-store` during CI

## Testing
- `pnpm test` *(fails: ps should return processes)*

------
https://chatgpt.com/codex/tasks/task_e_684881a5a4e883248fcca3fe91d2e253