### PR TITLE
Add lint and precommit scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ Kernel denies undeclared syscalls.
 4. `pnpm build:release` – cross-build Win/macOS/Linux/ARM.
 5. `helios snap path/to/out.helios` – CLI packs snapshot for Steam Workshop.
 6. **Modders:** drop TS file in `apps/`, run `makepkg`, publish to own apt repo.
+7. `pnpm lint` checks code style; a `precommit` script automatically runs
+   `pnpm lint && pnpm test` before each commit.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "build": "pnpm build:apps && esbuild ui/index.tsx --bundle --outfile=dist/bundle.js --target=esnext --platform=browser --tsconfig=tsconfig.json && cp ui/index.html dist/index.html",
     "build:release": "pnpm build && cd host && tauri build",
     "helios": "tsx tools/helios.ts",
-    "test": "vitest run"
+    "test": "vitest run",
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint -c .eslintrc.cjs \"**/*.{ts,tsx}\"",
+    "precommit": "pnpm lint && pnpm test"
   },
   "dependencies": {
     "@pablo-lion/xterm-react": "^1.1.2",


### PR DESCRIPTION
## Summary
- add lint and precommit scripts to package.json
- update developer workflow to mention linting and precommit step

## Testing
- `pnpm lint` *(fails: ESLint errors)*
- `pnpm test` *(fails: ps syscall returns processes)*

------
https://chatgpt.com/codex/tasks/task_e_68488b96b6ec8324ad6e1f338ee42bc1