### PR TITLE
Update workflow docs for unified build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,8 +218,8 @@ Kernel denies undeclared syscalls.
 
 1. `pnpm i` – installs deps, including `@xterm/*` (new scoped pkgs). ([github.com][7])
 2. `tsconfig.json` defines repo-wide TypeScript options (`target`/`module` set to `esnext`, `jsx` to `react`).
-3. `pnpm dev` – launches Tauri; `beforeDevCommand` starts the esbuild dev server automatically.
-4. `pnpm build:release` – cross-build Win/macOS/Linux/ARM.
+3. `pnpm dev` – launches Tauri. The unified build script runs in watch mode so the Vite dev server starts automatically.
+4. `pnpm build:release` – cross-build Win/macOS/Linux/ARM using the same build script.
 5. `helios snap path/to/out.helios` – CLI packs snapshot for Steam Workshop.
 6. **Modders:** drop TS file in `apps/`, run `makepkg`, publish to own apt repo.
 7. `pnpm lint` checks code style; a `precommit` script automatically runs

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -8,7 +8,7 @@ This project uses `pnpm` for managing Node dependencies and scripts.
     pnpm i
     ```
 
-2. Start the development environment (Tauri spawns the esbuild server automatically):
+2. Start the development environment. Tauri runs the unified build script in watch mode so the Vite dev server starts automatically:
 
     ```sh
     pnpm dev
@@ -17,13 +17,13 @@ This project uses `pnpm` for managing Node dependencies and scripts.
     pnpm dev:release
     ```
 
-3. Build a release bundle for distribution:
+3. Build a release bundle for distribution using the same script:
 
     ```sh
     pnpm build:release
     ```
 
-4. Run the test suite with **Vitest** before committing:
+4. Run the test suite with **Vitest** (powered by Vite) before committing:
 
     ```sh
     pnpm test


### PR DESCRIPTION
## Summary
- update docs to explain the unified build script
- note the Vite dev server integration and Vitest requirement

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6849868d18e483248e97781d1a98c189