### PR TITLE
Fix Tauri config and document build requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Kernel denies undeclared syscalls.
 2. `tsconfig.json` defines repo-wide TypeScript options (`target`/`module` set to `esnext`, `jsx` to `react`).
 3. `pnpm dev` – launches Tauri. The unified build script runs in watch mode so the Vite dev server starts automatically.
 4. `pnpm build:release` – cross-build Win/macOS/Linux/ARM using the same build script.
+   On Linux this step requires the `glib-2.0` development package; otherwise bundling fails with a `glib-2.0.pc` lookup error.
 5. `helios snap path/to/out.helios` – CLI packs snapshot for Steam Workshop.
 6. **Modders:** drop TS file in `apps/`, run `makepkg`, publish to own apt repo.
 7. `pnpm lint` checks code style; a `precommit` script automatically runs

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -23,6 +23,10 @@ This project uses `pnpm` for managing Node dependencies and scripts.
     pnpm build:release
     ```
 
+    On Linux the host requires the `glib-2.0` development
+    package. Without it the build fails with a missing
+    `glib-2.0.pc` error when bundling the Tauri binary.
+
 4. Run the test suite with **Vitest** (powered by Vite) before committing:
 
     ```sh

--- a/host/tauri.conf.json
+++ b/host/tauri.conf.json
@@ -1,39 +1,38 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
+  "productName": "helios-os",
+  "version": "0.1.0",
+  "identifier": "com.helios.dev",
   "build": {
-    "beforeDevCommand": "pnpm --dir .. dev:ui",
-    "beforeBuildCommand": "pnpm --dir .. build",
+    "beforeDevCommand": "pnpm dev:ui",
+    "beforeBuildCommand": "pnpm build",
     "devUrl": "http://localhost:1420/ui/index.html",
     "frontendDist": "../dist",
-    "withGlobalTauri": true
+    "runner": "pnpm"
   },
-  "package": {
-    "productName": "helios-os",
-    "version": "0.1.0"
-  },
-  "tauri": {
-    "bundle": {
-      "active": true,
-      "identifier": "com.helios.dev",
-      "icon": [
-        "../icons/32x32.png",
-        "../icons/128x128.png",
-        "../icons/128x128@2x.png",
-        "../icons/icon.icns",
-        "../icons/icon.ico"
-      ]
-    },
-    "security": {
-      "csp": null
-    },
+  "app": {
+    "withGlobalTauri": true,
     "windows": [
       {
-        "fullscreen": false,
+        "title": "Helios OS",
+        "width": 800,
         "height": 600,
         "resizable": true,
-        "title": "Helios OS",
-        "width": 800
+        "fullscreen": false
       }
+    ],
+    "security": {
+      "csp": null
+    }
+  },
+  "bundle": {
+    "active": true,
+    "icon": [
+      "../icons/32x32.png",
+      "../icons/128x128.png",
+      "../icons/128x128@2x.png",
+      "../icons/icon.icns",
+      "../icons/icon.ico"
     ]
   }
-} 
+}


### PR DESCRIPTION
## Summary
- update Tauri 2 configuration
- document Linux build dependency for Tauri

## Testing
- `pnpm test`
- `pnpm build:release` *(fails: glib-2.0.pc not found)*

------
https://chatgpt.com/codex/tasks/task_e_684987bb707c83249d9f8ed36c40604d