### PR TITLE
Improve docs and add contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing to Helios-OS
+
+Thank you for helping make Helios-OS better! This guide explains the coding conventions and common tasks in the repository.
+
+## Coding style
+
+- **Indentation:** 4 spaces. No tabs.
+- **Semicolons:** required.
+- **Trailing newline:** every file must end with a newline.
+- **Lint:** run `pnpm lint` before committing. The `precommit` script also runs `pnpm test`.
+- **TypeScript:** strict mode is enabled across the project; do not disable it.
+
+## Running tests
+
+The project uses [Vitest](https://vitest.dev/). Execute all tests with:
+
+```sh
+pnpm test
+```
+
+Vitest compiles the sources automatically so no extra build step is needed.
+
+## Adding or modifying a built-in CLI app
+
+1. Create a new file under `apps/cli/programs/` that exports an async `main(syscall, argv)` function.
+2. Run `pnpm build:apps` to regenerate `core/fs/generatedApps.ts`. This file embeds the program sources and manifests so they are available under `/bin` at runtime.
+3. Commit the updated `core/fs/generatedApps.ts` along with your program.
+
+## Adding a new syscall
+
+1. Implement the function in `core/kernel/syscalls.ts` following the pattern of existing syscalls.
+2. Export it and register the handler in `core/kernel/index.ts`.
+3. Update any relevant manifests in `tools/build-apps.ts` so user programs can request the new syscall.
+4. Add tests under `core/` exercising the new functionality.
+
+## Creating a new service daemon
+
+1. Add your service under `core/services/` exposing a `startXxx(kernel, opts)` function.
+2. Register the service in the kernel via `kernel.registerService()` or during snapshot restore.
+3. Document any ports or protocols in the service README.
+
+

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ For detailed guides on each component see the [docs directory](docs/README.md).
 ```
 helios/
 ├─ apps/
-│  ├─ cli/          # Built-in CLI commands
-│  │  └─ src/       # Source for bundled binaries
+│  ├─ cli/          # Built-in CLI programs
+│  │  └─ programs/  # Sources compiled into /bin
 │  └─ examples/     # Sample demo programs
 ├─ core/
 │  ├─ kernel.ts     # Syscall bus + scheduler
@@ -47,6 +47,9 @@ helios/
 ├─ ui/              # React windows, xterm bindings
 └─ tools/           # CLI for build/package/snapshot
 ```
+
+Built-in CLI programs are compiled into `/bin` via `pnpm build:apps`.
+Add new sources under `apps/cli/programs/` and rebuild to update `core/fs/generatedApps.ts`.
 
 ---
 

--- a/core/kernel/index.ts
+++ b/core/kernel/index.ts
@@ -188,6 +188,11 @@ export class Kernel {
         this.readyQueue = [];
     }
 
+    /**
+     * Create a new kernel instance. If a saved snapshot exists it will be
+     * restored so services, windows and processes resume exactly where they
+     * were on the last shutdown.
+     */
     public static async create(): Promise<Kernel> {
         const full = await loadKernelSnapshot();
         if (full) {
@@ -480,6 +485,10 @@ export class Kernel {
         return JSON.parse(JSON.stringify(state, replacer));
     }
 
+    /**
+     * Run the scheduler loop until {@link stop} is called. Each process in the
+     * ready queue receives a time slice according to its quota.
+     */
     public async start(): Promise<void> {
         this.running = true;
         while (this.running) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,3 +10,4 @@ This folder contains detailed guides covering each part of the project. Use the 
 - [User Interface](ui.md)
 - [Developer Workflow](workflow.md)
 - [GUI, Shell and Sandbox Roadmap](gui_shell_sandbox.md)
+- [Contributor Guide](../CONTRIBUTING.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,7 +15,7 @@ Each subsystem lives in its own directory:
 - `core/` – kernel, filesystem and networking implementations.
 - `host/` – Rust sidecar that hosts the V8 isolates and provides Tauri bindings.
 - `ui/` – front‑end windows and components.
-- `apps/` – example applications shipped with the OS.
+- `apps/` – built-in CLI programs (`cli/programs/`) and example GUI apps.
 - `tools/` – command line utilities for building and packaging snapshots.
 
 Snapshots contain the entire JSON state of a machine. The project aims for deterministic replay, so restoring a snapshot recreates the exact same runtime state.

--- a/docs/kernel_mvp.md
+++ b/docs/kernel_mvp.md
@@ -44,12 +44,13 @@ helios/
 │       ├─ pcb.ts
 │       └─ fdtable.ts
 ├─ apps/                 # userland programs
-│   ├─ echo.ts
-│   └─ cat.ts
+│   ├─ cli/programs/     # CLI utilities compiled into /bin
+│   └─ examples/         # sample GUI apps
 └─ ui/                   # React + xterm.js
 ```
 
 Core and apps are bundled with esbuild into a single JavaScript file that the host loads inside one V8 isolate.
+Built-in CLI programs are gathered by `tools/build-apps.ts` which writes `core/fs/generatedApps.ts`.
 
 ## Kernel State
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -37,3 +37,8 @@ This project uses `pnpm` for managing Node dependencies and scripts.
     required.
 
 The project enforces TypeScript strict mode. Use four spaces for indentation and ensure files end with a trailing newline.
+
+### Adding built-in CLI apps
+
+1. Add a new file in `apps/cli/programs/` that exports an async `main(syscall, argv)` function.
+2. Run `pnpm build:apps` to regenerate `core/fs/generatedApps.ts` and commit the result.


### PR DESCRIPTION
## Summary
- document repository layout and built-in app workflow
- add CONTRIBUTING guide with coding and testing rules
- update docs to reflect modularised apps
- link the contributor guide from docs index
- improve inline docs for kernel creation and syscalls

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684991d478748324a8553c5e55f35e32