### PR TITLE
Add cwd support and cd/pwd built-ins

### DIFF
--- a/core/kernel.test.ts
+++ b/core/kernel.test.ts
@@ -210,7 +210,7 @@ describe("Kernel", () => {
         kernelTest!.getState(procKernel).fs.createDirectory("/tmp", 0o755);
         kernelTest!.getState(procKernel).fs.createFile("/tmp/foo.txt", "bar", 0o644);
         const f = await kernelTest!.syscall_open(procKernel, procPcb, "/tmp/foo.txt", "r");
-        const fdList = await kernelTest!.syscall_readdir(procKernel, `/proc/${procPid}/fd`);
+        const fdList = await kernelTest!.syscall_readdir(procKernel, procPcb, `/proc/${procPid}/fd`);
         assert(
             fdList.some((n: any) => n.path === `/proc/${procPid}/fd/${f}`),
             "/proc/<pid>/fd lists open descriptors",

--- a/core/kernel/index.ts
+++ b/core/kernel/index.ts
@@ -86,6 +86,7 @@ export interface SpawnOpts {
     argv?: string[];
     uid?: number;
     gid?: number;
+    cwd?: string;
     quotaMs?: number;
     quotaMs_total?: number;
     quotaMem?: number;
@@ -368,6 +369,7 @@ export class Kernel {
             argv,
             syscalls: manifestSyscalls,
             ...opts,
+            cwd: opts.cwd ?? "/",
         });
     }
 
@@ -577,8 +579,11 @@ export const kernelTest = (typeof vitest !== "undefined" || process.env.VITEST)
               html: Uint8Array,
               opts: WindowOpts,
           ) => syscall_draw.call(k, html, opts),
-          syscall_readdir: (k: Kernel, path: string) =>
-              syscall_readdir.call(k, path),
+          syscall_readdir: (
+              k: Kernel,
+              pcb: ProcessControlBlock,
+              path: string,
+          ) => syscall_readdir.call(k, pcb, path),
           syscall_kill: (k: Kernel, pid: number, sig?: number) =>
               syscall_kill.call(k, pid, sig),
           syscall_set_quota: (

--- a/core/kernel/process.ts
+++ b/core/kernel/process.ts
@@ -19,6 +19,7 @@ export interface ProcessControlBlock {
     isolateId: number;
     uid: number;
     gid: number;
+    cwd: string;
     quotaMs: number;
     quotaMs_total: number;
     quotaMem: number;
@@ -44,6 +45,7 @@ export function createProcess(this: Kernel): ProcessID {
         isolateId: pid,
         uid: 1000,
         gid: 1000,
+        cwd: "/",
         quotaMs: 10,
         quotaMs_total: Infinity,
         quotaMem: 8 * 1024 * 1024,


### PR DESCRIPTION
## Summary
- track current working directory in PCBs
- resolve relative paths in filesystem syscalls
- expose `chdir` syscall
- support `cwd` when spawning processes
- implement `cd` and `pwd` in bash shell

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6849bc1846008324a0f0d08ce42ca896