### PR TITLE
Add clipboard hook and terminal integration

### DIFF
--- a/ui/hooks/clipboard.ts
+++ b/ui/hooks/clipboard.ts
@@ -1,0 +1,28 @@
+import { readText as tauriReadText, writeText as tauriWriteText } from "@tauri-apps/api/clipboard";
+
+export async function copyText(text: string): Promise<void> {
+    try {
+        if ((window as any).__TAURI__) {
+            await tauriWriteText(text);
+        } else if (navigator.clipboard) {
+            await navigator.clipboard.writeText(text);
+        }
+    } catch (e) {
+        console.error(e);
+    }
+}
+
+export async function pasteText(): Promise<string> {
+    try {
+        if ((window as any).__TAURI__) {
+            return (await tauriReadText()) ?? "";
+        }
+        if (navigator.clipboard) {
+            return await navigator.clipboard.readText();
+        }
+    } catch (e) {
+        console.error(e);
+    }
+    return "";
+}
+


### PR DESCRIPTION
## Summary
- add `clipboard` utilities for reading and writing text
- integrate clipboard copy/paste in `Terminal`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6849c3e9410083249478ca4fce3fc18e