### PR TITLE
Add basic GUI messaging

### DIFF
--- a/core/kernel.test.ts
+++ b/core/kernel.test.ts
@@ -186,7 +186,8 @@ describe("Kernel", () => {
         const snapKernel = kernelTest!.createKernel(new InMemoryFileSystem());
         kernelTest!.getState(snapKernel).fs.createDirectory("/snap", 0o755);
         kernelTest!.getState(snapKernel).fs.createFile("/snap/test.txt", "data", 0o644);
-        kernelTest!.syscall_draw(snapKernel, new TextEncoder().encode("<p>hi</p>"), { title: "t" });
+        const pcb = kernelTest!.getState(snapKernel).processes.get(1)!;
+        kernelTest!.syscall_draw(snapKernel, pcb, new TextEncoder().encode("<p>hi</p>"), { title: "t" });
         const hash1 = createHash("sha256")
             .update(JSON.stringify(kernelTest!.getState(snapKernel).fs.getSnapshot()))
             .digest("hex");

--- a/core/kernel/index.ts
+++ b/core/kernel/index.ts
@@ -153,6 +153,7 @@ export class Kernel {
     > = new Map();
     private nextJob = 1;
     private mountedVolumes: Map<string, string> = new Map();
+    private windowOwners: Map<number, ProcessID> = new Map();
     private createProcess = createProcess;
     private cleanupProcess = cleanupProcess;
     private ensureProcRoot = ensureProcRoot;
@@ -623,9 +624,10 @@ export const kernelTest = (typeof vitest !== "undefined" || process.env.VITEST)
           ) => syscall_read.call(k, pcb, fd, len),
           syscall_draw: (
               k: Kernel,
+              pcb: ProcessControlBlock,
               html: Uint8Array,
               opts: WindowOpts,
-          ) => syscall_draw.call(k, html, opts),
+          ) => syscall_draw.call(k, pcb, html, opts),
           syscall_readdir: (
               k: Kernel,
               pcb: ProcessControlBlock,

--- a/core/kernel/syscalls.ts
+++ b/core/kernel/syscalls.ts
@@ -79,7 +79,7 @@ export function createSyscallDispatcher(
             case "udp_send":
                 return this.syscall_udp_send(args[0], args[1]);
             case "draw":
-                return this.syscall_draw(args[0], args[1]);
+                return this.syscall_draw(pcb, args[0], args[1]);
             case "mkdir":
                 return await this.syscall_mkdir(pcb, args[0], args[1]);
             case "readdir":
@@ -388,6 +388,7 @@ export function sys_remove_monitor(this: Kernel, id: number): number {
  */
 export function syscall_draw(
     this: Kernel,
+    pcb: ProcessControlBlock,
     html: Uint8Array,
     opts: WindowOpts,
 ): number {
@@ -401,6 +402,7 @@ export function syscall_draw(
         opts,
     };
     eventBus.emit("desktop.createWindow", payload);
+    (this as any).windowOwners?.set(id, pcb.pid);
     return id;
 }
 

--- a/core/utils/eventBus.ts
+++ b/core/utils/eventBus.ts
@@ -6,10 +6,17 @@ export interface DrawPayload {
     opts: WindowOpts;
 }
 
+export interface WindowMessagePayload {
+    id: number;
+    data: unknown;
+}
+
 export interface EventMap {
     draw: DrawPayload;
     "desktop.createWindow": DrawPayload;
     "desktop.updateMonitors": Monitor[];
+    "desktop.windowPost": WindowMessagePayload;
+    "desktop.windowRecv": WindowMessagePayload;
     "boot.shellReady": { pid: number };
     "system.reboot": {};
 }

--- a/lib/gui.d.ts
+++ b/lib/gui.d.ts
@@ -1,0 +1,5 @@
+import type { WindowOpts } from "../core/kernel";
+
+export declare function createWindow(html: string, opts: WindowOpts): number;
+export declare function postMessage(winId: number, data: unknown): void;
+export declare function onMessage(winId: number, handler: (data: unknown) => void): void;


### PR DESCRIPTION
## Summary
- declare GUI helper types in `lib/gui.d.ts`
- extend EventBus with window message events
- track owning PID for windows and update draw syscall
- forward messages to and from iframes in `Window` component
- update desktop panel example to use new message API
- adjust tests for new draw syscall signature

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6849c79a7f408324a8ed248c0c5c60e9