### PR TITLE
Add helios new cli-app command

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Kernel denies undeclared syscalls.
 4. `pnpm build:release` – cross-build Win/macOS/Linux/ARM using the same build script.
    On Linux this step requires the `glib-2.0` development package; otherwise bundling fails with a `glib-2.0.pc` lookup error.
 5. `helios snap path/to/out.helios` – CLI packs snapshot for Steam Workshop.
-6. `helios new gui-app my-app` – scaffold a sample GUI app under `apps/examples/`.
+6. `helios new gui-app my-app` or `helios new cli-app my-app` – scaffold sample apps under `apps/examples/`.
 7. `pnpm update-snapshot` – refresh `snapshot.json` using the built-in tool.
 8. **Modders:** drop TS file in `apps/`, run `makepkg`, publish to own apt repo.
 9. `apt search foo` lists packages from `/etc/apt/index.json`; `apt install foo` installs them into `/usr/bin`.

--- a/tools/helios.ts
+++ b/tools/helios.ts
@@ -20,20 +20,76 @@ export async function makepkg(dir: string) {
     console.log(`Package created: ${outName}`);
 }
 
+async function writeBuildScript(
+    dir: string,
+    entry: string,
+    platform: "browser" | "node",
+) {
+    const build = `import { build } from 'esbuild';\n` +
+        `import { copyFile, mkdir } from 'fs/promises';\n\n` +
+        `await mkdir('dist', { recursive: true });\n` +
+        `await build({\n` +
+        `    entryPoints: ['${entry}'],\n` +
+        `    bundle: true,\n` +
+        `    outfile: 'dist/bundle.js',\n` +
+        `    platform: '${platform}',\n` +
+        `    tsconfig: '../../tsconfig.json',\n` +
+        `});\n` +
+        (platform === "browser"
+            ? `await copyFile('index.html', 'dist/index.html');\n`
+            : "");
+    await fs.writeFile(path.join(dir, "build.ts"), build);
+}
+
 export async function scaffoldGuiApp(name: string) {
     const dir = path.join("apps", "examples", name);
     await fs.mkdir(dir, { recursive: true });
-    const mainPath = path.join(dir, "index.tsx");
-    const code = `import type { SyscallDispatcher } from '../../types/syscalls';
+    await fs.writeFile(
+        path.join(dir, "main.tsx"),
+        `import type { SyscallDispatcher } from '../../types/syscalls';\n\n` +
+            `export async function main(syscall: SyscallDispatcher): Promise<number> {\n` +
+            `    const html = new TextEncoder().encode('<h1>${name} works!</h1>');\n` +
+            `    await syscall('draw', html, { title: '${name}' });\n` +
+            `    return 0;\n` +
+            `}\n`,
+    );
 
-export async function main(syscall: SyscallDispatcher): Promise<number> {
-    const html = new TextEncoder().encode('<h1>${name} works!</h1>');
-    await syscall('draw', html, { title: '${name}' });
-    return 0;
-}
-`;
-    await fs.writeFile(mainPath, code);
+    await fs.writeFile(
+        path.join(dir, "index.html"),
+        `<!DOCTYPE html>\n<html lang='en'>\n<head>\n    <meta charset='UTF-8'>\n    <title>${name}</title>\n</head>\n<body>\n    <div id='root'></div>\n    <script src='./bundle.js'></script>\n</body>\n</html>\n`,
+    );
+
+    await fs.writeFile(
+        path.join(dir, "pkg.json"),
+        JSON.stringify({ name, version: "0.1.0", syscalls: [] }, null, 2) + "\n",
+    );
+
+    await writeBuildScript(dir, "main.tsx", "browser");
+
     console.log(`GUI app created at ${dir}`);
+}
+
+export async function scaffoldCliApp(name: string) {
+    const dir = path.join("apps", "examples", name);
+    await fs.mkdir(dir, { recursive: true });
+
+    await fs.writeFile(
+        path.join(dir, "main.ts"),
+        `import type { SyscallDispatcher } from '../../types/syscalls';\n\n` +
+            `export async function main(syscall: SyscallDispatcher): Promise<number> {\n` +
+            `    await syscall('write', 1, new TextEncoder().encode('${name} works!\n'));\n` +
+            `    return 0;\n` +
+            `}\n`,
+    );
+
+    await fs.writeFile(
+        path.join(dir, "pkg.json"),
+        JSON.stringify({ name, version: "0.1.0", syscalls: [] }, null, 2) + "\n",
+    );
+
+    await writeBuildScript(dir, "main.ts", "node");
+
+    console.log(`CLI app created at ${dir}`);
 }
 
 export async function updateSnapshot(outPath = "snapshot.json") {
@@ -46,7 +102,10 @@ export async function updateSnapshot(outPath = "snapshot.json") {
 export async function main() {
     const [command, sub, arg] = process.argv.slice(2);
     if (!command) {
-        console.log("Usage: helios <snap|makepkg|new|update-snapshot> [args]");
+        console.log(
+            "Usage: helios <snap|makepkg|new|update-snapshot> [args]\n" +
+                "       helios new <gui-app|cli-app> <name>",
+        );
         process.exit(1);
     }
     switch (command) {
@@ -59,11 +118,12 @@ export async function main() {
             await makepkg(sub);
             break;
         case "new":
-            if (sub !== "gui-app" || !arg) {
-                console.log("Usage: helios new gui-app <name>");
+            if (!arg || (sub !== "gui-app" && sub !== "cli-app")) {
+                console.log("Usage: helios new <gui-app|cli-app> <name>");
                 process.exit(1);
             }
-            await scaffoldGuiApp(arg);
+            if (sub === "gui-app") await scaffoldGuiApp(arg);
+            else await scaffoldCliApp(arg);
             break;
         case "update-snapshot":
             await updateSnapshot(sub ?? "snapshot.json");


### PR DESCRIPTION
## Summary
- support scaffolding CLI and GUI apps via `helios new`
- add usage hints to the tool and update developer workflow docs

## Testing
- `pnpm test`
- `pnpm lint` *(fails: many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6849cb7be2fc8324bee0cb98d601efbb