### PR TITLE
Add apt remove support

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Kernel denies undeclared syscalls.
 6. `helios new gui-app my-app` or `helios new cli-app my-app` – scaffold sample apps under `apps/examples/`.
 7. `pnpm update-snapshot` – refresh `snapshot.json` using the built-in tool.
 8. **Modders:** drop TS file in `apps/`, run `makepkg`, publish to own apt repo.
-9. `apt search foo` lists packages from `/etc/apt/index.json`; `apt install foo` installs them into `/usr/bin`.
+9. `apt search foo` lists packages from `/etc/apt/index.json`; `apt install foo` installs them into `/usr/bin`; `apt remove foo` cleans them up.
 10. `pnpm lint` checks code style; a `precommit` script automatically runs
    `pnpm lint && pnpm test` before each commit.
 


### PR DESCRIPTION
## Summary
- support `apt remove` command with package manifest tracking
- record installed files under `/var/pkg/<name>.json`
- document `apt remove` for modders in README

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6849cc58e9048324ad0c8a5c64b9cff3