### PR TITLE
Add crash overlay with restart

### DIFF
--- a/core/kernel/syscalls.ts
+++ b/core/kernel/syscalls.ts
@@ -294,6 +294,8 @@ export async function syscall_spawn(
     if (opts.tty !== undefined) pcb.tty = opts.tty;
     if (opts.syscalls) pcb.allowedSyscalls = new Set(opts.syscalls);
     pcb.code = code;
+    pcb.spawnCode = code;
+    pcb.spawnOpts = { ...opts };
     pcb.argv = opts.argv ?? [];
     this.readyQueue.push(pcb);
     if (code === BASH_SOURCE) {

--- a/core/utils/eventBus.ts
+++ b/core/utils/eventBus.ts
@@ -1,4 +1,5 @@
 import type { WindowOpts, Monitor } from "./kernel";
+import type { SpawnOptions } from "../kernel/syscalls";
 
 export interface DrawPayload {
     id: number;
@@ -17,6 +18,7 @@ export interface EventMap {
     "desktop.updateMonitors": Monitor[];
     "desktop.windowPost": WindowMessagePayload;
     "desktop.windowRecv": WindowMessagePayload;
+    "desktop.appCrashed": { id: number; code: string; opts: SpawnOptions };
     "boot.shellReady": { pid: number };
     "system.reboot": {};
 }

--- a/ui/components/Window.css
+++ b/ui/components/Window.css
@@ -8,6 +8,7 @@
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
   border-radius: 8px;
   overflow: hidden;
+  position: relative;
 }
 
 /* Style for the title bar */
@@ -66,6 +67,21 @@
   display: flex; /* Make content fill space */
   flex-direction: column;
   overflow: hidden; /* Hide overflow from children */
+}
+
+.crash-overlay {
+  position: absolute;
+  top: 32px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  gap: 8px;
 }
 
 /* Let the terminal itself fill the content area */

--- a/ui/components/Window.tsx
+++ b/ui/components/Window.tsx
@@ -23,6 +23,7 @@ export interface WindowProps {
     monitorId: number;
     monitors: Monitor[];
     onChangeMonitor?: (id: number) => void;
+    overlay?: React.ReactNode;
 }
 
 export interface WindowHandles {
@@ -50,6 +51,7 @@ export const Window = forwardRef<WindowHandles, WindowProps>(
             monitorId,
             monitors,
             onChangeMonitor,
+            overlay,
         },
         ref,
     ) => {
@@ -185,6 +187,7 @@ export const Window = forwardRef<WindowHandles, WindowProps>(
                             </select>
                         </div>
                         <div className="window-content">{content}</div>
+                        {overlay}
                     </ResizableBox>
                 </div>
             </Draggable>

--- a/ui/index.tsx
+++ b/ui/index.tsx
@@ -53,7 +53,11 @@ const App = () => {
     );
 
     return (
-        <WindowManager ref={windowManagerRef} onResize={handleResize}>
+        <WindowManager
+            ref={windowManagerRef}
+            onResize={handleResize}
+            kernel={kernel}
+        >
             {!shellReady ? (
                 <div style={{ color: COLORS.foreground, padding: "10px" }}>
                     Booting...


### PR DESCRIPTION
## Summary
- emit `desktop.appCrashed` when processes exit with error
- track original spawn code/opts and pass in crash event
- handle crash events in `WindowManager` and show overlay
- allow windows to overlay custom elements
- expose restart button that re-spawns crashed apps

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6849d27db28c832480c0051c6ec950e1