### PR TITLE
Update workflow docs and add GUI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,9 +227,10 @@ Kernel denies undeclared syscalls.
 5. `helios snap path/to/out.helios` – CLI packs snapshot for Steam Workshop.
 6. `helios new gui-app my-app` or `helios new cli-app my-app` – scaffold sample apps under `apps/examples/`.
 7. `pnpm update-snapshot` – refresh `snapshot.json` using the built-in tool.
-8. **Modders:** drop TS file in `apps/`, run `makepkg`, publish to own apt repo.
+8. **Modders:** build packages with `pnpm helios makepkg apps/examples/my-app` and publish them using `pnpm helios publish my-app-0.1.0.tar.gz`.
 9. `apt search foo` lists packages from `/etc/apt/index.json`; `apt install foo` installs them into `/usr/bin`; `apt remove foo` cleans them up.
-10. `pnpm lint` checks code style; a `precommit` script automatically runs
+10. Communicate between windows with `postMessage` and watch for `desktop.appCrashed` events when a process dies.
+11. `pnpm lint` checks code style; a `precommit` script automatically runs
    `pnpm lint && pnpm test` before each commit.
 
 ---

--- a/apps/examples/helloGui.ts
+++ b/apps/examples/helloGui.ts
@@ -1,0 +1,7 @@
+import { createWindow, postMessage, onMessage } from "../../lib/gui";
+
+export async function runHelloGui() {
+    const id = await createWindow("<h1>Hello World</h1>", { title: "Hello" });
+    onMessage(id, (data) => console.log("helloGui received", data));
+    postMessage(0, id, { greeting: "hello" });
+}

--- a/apps/index.ts
+++ b/apps/index.ts
@@ -2,6 +2,7 @@ export * from "./examples/browser";
 export * from "./examples/sshClient";
 export * from "./examples/desktop";
 export * from "./examples/webBrowser";
+export * from "./examples/helloGui";
 
 export * from "./cli/programs/bash";
 export * from "./cli/programs/init";

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -43,16 +43,46 @@ The project enforces TypeScript strict mode. Use four spaces for indentation and
 1. Add a new file in `apps/cli/programs/` that exports an async `main(syscall, argv)` function.
 2. Run `pnpm build:apps` to regenerate `core/fs/generatedApps.ts` and commit the result.
 
-### Creating a new GUI app
+### Creating new apps
 
-Run the CLI scaffolding command:
+Run the CLI scaffolding command for GUI or CLI programs:
 
 ```sh
-pnpm helios new gui-app my-app
+pnpm helios new gui-app my-gui
+pnpm helios new cli-app my-cli
 ```
 
-This generates `apps/examples/my-app/index.tsx` with a basic window example. Build the apps afterwards using `pnpm build:apps`.
-Use `pnpm update-snapshot` to refresh the default snapshot after adding new programs.
+This generates a folder under `apps/examples/` with boilerplate code. Build the apps afterwards using `pnpm build:apps` and update the default snapshot with `pnpm update-snapshot`.
+
+### Packaging and publishing
+
+The `helios` CLI can bundle a directory into a package:
+
+```sh
+pnpm helios makepkg apps/examples/my-gui
+```
+
+Install the resulting archive inside the VM with `apt install <pkg>` and remove it with `apt remove <pkg>`.
+
+To publish a package to the local workshop directory run:
+
+```sh
+pnpm helios publish my-gui-0.1.0.tar.gz
+```
+
+### Messaging and crash handling
+
+GUI windows communicate via `postMessage`:
+
+```ts
+import { postMessage, onMessage } from "../../lib/gui";
+
+const id = await createWindow("<p>Hello</p>", { title: "demo" });
+onMessage(id, (data) => console.log("got", data));
+postMessage(0, id, { ping: true });
+```
+
+Listen for `desktop.appCrashed` on the event bus to be notified when a process terminates unexpectedly.
 
 ### Continuous Integration
 


### PR DESCRIPTION
## Summary
- document app scaffolding, packaging and messaging workflow
- mention makepkg/publish/apt install and postMessage crash handling in README
- add a Hello World GUI example

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6849dc25dc188324885b5fe1601aaf20