### PR TITLE
Add ICMP echo and ping over UDP

### DIFF
--- a/apps/cli/programs/ping.ts
+++ b/apps/cli/programs/ping.ts
@@ -4,12 +4,12 @@ export async function main(syscall: SyscallDispatcher, argv: string[]): Promise<
     const STDOUT_FD = 1;
     const STDERR_FD = 2;
     const encode = (s: string) => new TextEncoder().encode(s);
-    const ip = argv[0] || '127.0.0.1';
-    const port = argv[1] ? parseInt(argv[1], 10) : 7;
+    const ip = argv[0] || "127.0.0.1";
+    const port = argv[1] ? parseInt(argv[1], 10) : 0;
     try {
-        const sock = await syscall('connect', ip, port);
+        const sock = await syscall("udp_connect", ip, port);
         const start = Date.now();
-        const resp = await syscall('tcp_send', sock, encode('ping'));
+        const resp = await syscall("udp_send", sock, encode("ping"));
         const end = Date.now();
         if (resp) {
             await syscall('write', STDOUT_FD, encode('pong ' + (end - start) + 'ms\n'));
@@ -23,3 +23,4 @@ export async function main(syscall: SyscallDispatcher, argv: string[]): Promise<
     }
     return 0;
 }
+

--- a/apps/types/syscalls.d.ts
+++ b/apps/types/syscalls.d.ts
@@ -10,6 +10,7 @@ export interface SyscallDispatcher {
     (call: "spawn", code: string, opts?: any): Promise<ProcessID>;
     (call: "listen", port: number, proto: string, cb: ServiceHandler): Promise<number>;
     (call: "connect", ip: string, port: number): Promise<number>;
+    (call: "udp_connect", ip: string, port: number): Promise<number>;
     (call: "tcp_send" | "udp_send", sock: number, data: Uint8Array): Promise<number>;
     (call: "draw", html: Uint8Array, opts: WindowOpts): Promise<number>;
     (call: "mkdir", path: string, perms: number): Promise<number>;
@@ -40,3 +41,4 @@ export interface SyscallDispatcher {
     (call: string, ...args: any[]): Promise<any>;
 }
 export {};
+

--- a/core/kernel/index.ts
+++ b/core/kernel/index.ts
@@ -90,6 +90,7 @@ import {
     syscall_kill,
     syscall_listen,
     syscall_connect,
+    syscall_udp_connect,
     syscall_tcp_send,
     syscall_udp_send,
     syscall_draw,
@@ -213,6 +214,7 @@ export class Kernel {
     private syscall_kill = syscall_kill;
     private syscall_listen = syscall_listen;
     private syscall_connect = syscall_connect;
+    private syscall_udp_connect = syscall_udp_connect;
     private syscall_tcp_send = syscall_tcp_send;
     private syscall_udp_send = syscall_udp_send;
     private syscall_draw = syscall_draw;

--- a/core/kernel/syscalls.ts
+++ b/core/kernel/syscalls.ts
@@ -74,6 +74,8 @@ export function createSyscallDispatcher(
                 return this.syscall_listen(args[0], args[1], args[2]);
             case "connect":
                 return this.syscall_connect(args[0], args[1]);
+            case "udp_connect":
+                return this.syscall_udp_connect(args[0], args[1]);
             case "tcp_send":
                 return this.syscall_tcp_send(args[0], args[1]);
             case "udp_send":
@@ -375,6 +377,17 @@ export function syscall_connect(
     port: number,
 ): number {
     return this.state.tcp.connect(ip, port);
+}
+
+/**
+ * Open a UDP socket to the given address and return a socket id.
+ */
+export function syscall_udp_connect(
+    this: Kernel,
+    ip: string,
+    port: number,
+): number {
+    return this.state.udp.connect(ip, port);
 }
 
 /**

--- a/core/net/icmp.ts
+++ b/core/net/icmp.ts
@@ -1,0 +1,27 @@
+export const ICMP_ECHO_PORT = 0;
+
+export type IcmpHandler = (
+    data: Uint8Array,
+    from: { ip: string }
+) => Promise<Uint8Array | void> | Uint8Array | void;
+
+export class ICMP {
+    private handler: IcmpHandler | null = null;
+    constructor(private udp: { listen: (p: number, h: IcmpHandler) => number; unlisten: (p: number) => void; connect: (ip: string, port: number) => number; send: (sock: number, data: Uint8Array) => Promise<Uint8Array | void>; }) {}
+
+    listen(handler: IcmpHandler): number {
+        this.handler = handler;
+        return this.udp.listen(ICMP_ECHO_PORT, (d, src) => handler(d, { ip: src.ip }));
+    }
+
+    unlisten(): void {
+        this.handler = null;
+        this.udp.unlisten(ICMP_ECHO_PORT);
+    }
+
+    ping(ip: string, data: Uint8Array): Promise<Uint8Array | void> {
+        const sock = this.udp.connect(ip, ICMP_ECHO_PORT);
+        return this.udp.send(sock, data);
+    }
+}
+

--- a/core/services/ping.ts
+++ b/core/services/ping.ts
@@ -5,7 +5,8 @@ export interface PingOptions {
 }
 
 export function startPingService(kernel: Kernel, opts: PingOptions = {}): void {
-    const port = opts.port ?? 7;
+    const port = opts.port ?? 0;
     const handler: ServiceHandler = async (data) => data;
-    kernel.registerService(`pingd:${port}`, port, "tcp", handler);
+    kernel.registerService(`pingd:${port}`, port, "udp", handler);
 }
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,4 +11,5 @@ This folder contains detailed guides covering each part of the project. Use the 
 - [Theme Creation](themes.md)
 - [Developer Workflow](workflow.md)
 - [GUI, Shell and Sandbox Roadmap](gui_shell_sandbox.md)
+- [Networking Example](network_example.md)
 - [Contributor Guide](../CONTRIBUTING.md)

--- a/docs/network_example.md
+++ b/docs/network_example.md
@@ -1,0 +1,21 @@
+# Networking Example
+
+This short guide shows how services can communicate once routing is configured.
+
+1. Start the HTTP daemon on one VM:
+
+```ts
+import { startHttpd } from "../core/services/http";
+
+startHttpd(kernel, { port: 8080 });
+```
+
+2. From another VM send a request using `curl` (or `cat` with a TCP client):
+
+```sh
+$ curl 10.0.0.2:8080
+Hello from Helios HTTP on port 8080
+```
+
+Routing between instances is required so packets reach the HTTP service.
+

--- a/tools/build-apps.ts
+++ b/tools/build-apps.ts
@@ -12,7 +12,7 @@ const manifests: Record<string, any> = {
     echo: { name: "echo", syscalls: ["open", "write", "close"] },
     nano: { name: "nano", syscalls: ["open", "read", "write", "close", "draw"] },
     browser: { name: "browser", syscalls: ["draw"] },
-    ping: { name: "ping", syscalls: ["connect", "tcp_send", "write"] },
+    ping: { name: "ping", syscalls: ["udp_connect", "udp_send", "write"] },
     desktop: { name: "desktop", syscalls: ["open", "read", "write", "close", "spawn", "draw"] },
     startx: { name: "startx", syscalls: ["open", "read", "write", "close", "spawn"] },
     ls: { name: "ls", syscalls: ["readdir", "write"] },


### PR DESCRIPTION
## Summary
- implement ICMP echo helper built on UDP
- use new UDP ping in `ping` program
- expose `udp_connect` syscall
- update ping service for UDP
- document cross-instance HTTP usage

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684ae05cf0c08324adcafb65c08efd51