### PR TITLE
Add networking docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,11 +242,11 @@ Kernel denies undeclared syscalls.
 | ----- | ----------------------------------- | ------------------------------- |
 | 1-2   | Kernel MVP: spawn, FS, `echo`.      | `cat /etc/issue` prints.        |
 | 3-4   | Window mgr + xterm.js.              | Drag windows, resize terminal.  |
-| 5-6   | TCP stack + ping loopback.          | `ping 127.0.0.1` < 10 ms.       |
-| 7     | Switch + router; cross-subnet ping. | Ping across /24.                |
-| 8     | HTTP daemon & browser app.          | Serve page inside VM.           |
+| 5-6   | TCP stack with `ping` and `ifconfig`.          | `ping 127.0.0.1` < 10 ms.       |
+| 7     | Switch + router; `route` works. | Ping across /24.                |
+| 8     | HTTP daemon & browser app; `iwlist`/`iwconfig`.          | Serve page inside VM. |
 | 9     | SSH mock login over LAN.            | Remote shell works.             |
-| 10    | DNS + DHCP.                         | `curl http://foo.vm` resolves.  |
+| 10    | DNS + DHCP via `dhclient`.                         | `curl http://foo.vm` resolves.  |
 | 11    | apt repo + `apt install nano`.      | Editor launches.                |
 | 12-13 | P2P coin ledger.                    | 3-node chain reaches consensus. |
 | 14    | MMO world router alpha.             | Two clients share ping 80 ms.   |

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,4 +12,5 @@ This folder contains detailed guides covering each part of the project. Use the 
 - [Developer Workflow](workflow.md)
 - [GUI, Shell and Sandbox Roadmap](gui_shell_sandbox.md)
 - [Networking Example](network_example.md)
+- [Networking Tools](networking.md)
 - [Contributor Guide](../CONTRIBUTING.md)

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -1,0 +1,49 @@
+# Networking Tools
+
+This page describes the basic CLI utilities bundled with Helios-OS for
+managing network interfaces and testing connectivity. These commands
+mirror common Linux tools but run entirely within the TypeScript kernel.
+
+## ifconfig
+
+`ifconfig` lists and configures network interfaces. Without arguments it
+shows all NICs with their IP, netmask and status. `ifconfig eth0 up`
+brings an interface online, `ifconfig wlan0 down` disables it and
+`ifconfig eth0 10.0.0.2/24` sets an address manually.
+
+## dhclient
+
+`dhclient <nic>` requests an IP address from the local DHCP service. On
+success the assigned address and mask are printed. The kernel keeps the
+lease so subsequent `ifconfig` calls display it.
+
+## iwlist
+
+`iwlist` scans for nearby Wi‑Fi networks and prints the SSIDs detected.
+It relies on the host exposing wireless NICs to the kernel.
+
+## iwconfig
+
+`iwconfig <nic> <ssid> <passphrase>` connects a wireless interface to a
+network. The command fails if authentication does not succeed.
+
+## route
+
+The `route` utility adds or removes entries from the routing table.
+`route add 192.168.0.0/24 eth0` directs packets for that subnet through a
+specific interface while `route del 192.168.0.0/24` removes the rule.
+
+## ping
+
+`ping <ip>` sends a UDP echo and reports the round-trip time. It is
+useful for verifying that routes are configured correctly.
+
+## Host hub communication
+
+When running multiple Helios instances on the same machine the host acts
+as a virtual hub. Each VM sends its Ethernet frames to the host which
+forwards them to all other active instances. This allows local
+multiplayer testing without an external router. When MMO mode is
+enabled the host hub tunnels frames to the world router so remote
+players share the same simulated network.
+


### PR DESCRIPTION
## Summary
- document network tools and host hub
- link new networking docs from docs README
- reference ifconfig, route, dhclient and other utilities in roadmap

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684ae779116c83248e92ff2c1ce1c75e