### PR TITLE
Add PTY manager and TTY device support

### DIFF
--- a/core/fs/index.ts
+++ b/core/fs/index.ts
@@ -104,6 +104,13 @@ export class InMemoryFileSystem implements AsyncFileSystem {
         this.createDirectory("/etc", 0o755);
         this.createFile("/etc/issue", "Welcome to Helios-OS v0.1\n", 0o644);
 
+        this.createDirectory("/dev", 0o755);
+        this.createFile("/dev/tty0", new Uint8Array(), 0o666);
+        this.createFile("/dev/tty1", new Uint8Array(), 0o666);
+        this.createFile("/dev/pty0", new Uint8Array(), 0o666);
+        this.createFile("/dev/pty1", new Uint8Array(), 0o666);
+        this.createVirtualFile("/dev/ptmx", () => new Uint8Array(), 0o666);
+
         this.createDirectory("/bin", 0o755);
         this.createFile("/bin/cat", CAT_SOURCE, 0o755);
         this.createFile("/bin/cat.manifest.json", CAT_MANIFEST, 0o644);
@@ -140,7 +147,14 @@ export class InMemoryFileSystem implements AsyncFileSystem {
         this.createFile("/bin/bash", BASH_SOURCE, 0o755);
         this.createFile("/bin/bash.manifest.json", BASH_MANIFEST, 0o644);
 
-        const bundled = (globalThis as { BUNDLED_DISK_IMAGES?: Array<{ image: FileSystemSnapshot; path: string }> }).BUNDLED_DISK_IMAGES;
+        const bundled = (
+            globalThis as {
+                BUNDLED_DISK_IMAGES?: Array<{
+                    image: FileSystemSnapshot;
+                    path: string;
+                }>;
+            }
+        ).BUNDLED_DISK_IMAGES;
         if (bundled) {
             for (const m of bundled) {
                 try {

--- a/core/kernel/process.ts
+++ b/core/kernel/process.ts
@@ -13,6 +13,8 @@ export interface FileDescriptorEntry {
     position: number;
     flags: string;
     virtual?: boolean;
+    ttyId?: number;
+    ttySide?: "master" | "slave";
 }
 
 export interface ProcessControlBlock {

--- a/core/kernel/tty.ts
+++ b/core/kernel/tty.ts
@@ -1,0 +1,38 @@
+export type TtySide = "master" | "slave";
+
+class Pty {
+    public masterBuffer: number[] = [];
+    public slaveBuffer: number[] = [];
+    constructor(public id: number) {}
+}
+
+export class PtyManager {
+    private nextId = 0;
+    private ptys: Map<number, Pty> = new Map();
+
+    allocate(): { id: number; master: string; slave: string } {
+        const id = this.nextId++;
+        const pty = new Pty(id);
+        this.ptys.set(id, pty);
+        return { id, master: `/dev/pty${id}`, slave: `/dev/tty${id}` };
+    }
+
+    exists(id: number): boolean {
+        return this.ptys.has(id);
+    }
+
+    write(id: number, side: TtySide, data: Uint8Array): void {
+        const pty = this.ptys.get(id);
+        if (!pty) return;
+        const target = side === "master" ? pty.slaveBuffer : pty.masterBuffer;
+        for (const b of data) target.push(b);
+    }
+
+    read(id: number, side: TtySide, length: number): Uint8Array {
+        const pty = this.ptys.get(id);
+        if (!pty) return new Uint8Array();
+        const buf = side === "master" ? pty.masterBuffer : pty.slaveBuffer;
+        const out: number[] = buf.splice(0, length);
+        return Uint8Array.from(out);
+    }
+}


### PR DESCRIPTION
## Summary
- add new `PtyManager` for allocating pseudo terminals
- expose `/dev/tty*` and `/dev/ptmx` in the filesystem
- extend spawn options and syscalls for PTY usage
- wire PTY handling into open/read/write operations
- update bash and login apps to use their TTY device for I/O
- test PTY allocation and `/proc/<pid>/status` reporting

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684aeced67d4832494cdbafc736fb734