### PR TITLE
Implement SSH PTY support

### DIFF
--- a/apps/examples/sshClient.ts
+++ b/apps/examples/sshClient.ts
@@ -3,7 +3,16 @@ import { startSshd } from "../../core/services/ssh";
 
 export async function runSshExample(kernel: Kernel) {
     startSshd(kernel, { port: 2222 });
-    // Connect to the local SSH service
+    const enc = new TextEncoder();
+    const dec = new TextDecoder();
     const conn = (kernel as any).tcp.connect("127.0.0.1", 2222);
-    conn.write(new TextEncoder().encode("\n"));
+    conn.onData((d: Uint8Array) => {
+        console.log(dec.decode(d));
+    });
+    conn.write(enc.encode("user\n"));
+    conn.write(enc.encode("pass\n"));
+    setTimeout(() => {
+        conn.write(enc.encode("echo hi\n"));
+    }, 50);
 }
+

--- a/core/services/ssh.ts
+++ b/core/services/ssh.ts
@@ -6,15 +6,57 @@ export interface SshOptions {
 
 export function startSshd(kernel: Kernel, opts: SshOptions = {}): void {
     const port = opts.port ?? 22;
-    const greeting = new TextEncoder().encode("Welcome to Helios SSH\n");
+    const enc = new TextEncoder();
+    const dec = new TextDecoder();
+
     kernel.registerService(`sshd:${port}`, port, "tcp", {
         onConnect(conn: TcpConnection) {
-            conn.write(greeting);
+            conn.write(enc.encode("login: "));
+            let stage: "user" | "pass" | "shell" = "user";
+            let user = "";
+            let pass = "";
+            let ptyId: number | null = null;
+
+            const ptys = (kernel as any).ptys;
+            const fs = (kernel as any).state.fs as any;
+
+            function startShell() {
+                const alloc = ptys.allocate();
+                if (!fs.getNode(alloc.master)) fs.createFile(alloc.master, new Uint8Array(), 0o666);
+                if (!fs.getNode(alloc.slave)) fs.createFile(alloc.slave, new Uint8Array(), 0o666);
+                ptyId = alloc.id;
+                void kernel.spawn(`bash tty${alloc.id}`, { tty: alloc.slave });
+                setInterval(() => {
+                    if (ptyId === null) return;
+                    const out = ptys.read(ptyId, "master", 1024);
+                    if (out.length > 0) conn.write(out);
+                }, 10);
+            }
+
             conn.onData((data) => {
-                const cmd = new TextDecoder().decode(data).trim();
-                if (cmd.length === 0) return;
-                const resp = new TextEncoder().encode("Unknown command\n");
-                conn.write(resp);
+                if (stage === "shell") {
+                    if (ptyId !== null) ptys.write(ptyId, "master", data);
+                    return;
+                }
+                const text = dec.decode(data);
+                for (const ch of text) {
+                    if (stage === "user") {
+                        if (ch === "\n") {
+                            stage = "pass";
+                            conn.write(enc.encode("password: "));
+                        } else {
+                            user += ch;
+                        }
+                    } else if (stage === "pass") {
+                        if (ch === "\n") {
+                            stage = "shell";
+                            conn.write(enc.encode("\nWelcome to Helios-OS\n"));
+                            startShell();
+                        } else {
+                            pass += ch;
+                        }
+                    }
+                }
             });
         },
     });

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -47,3 +47,18 @@ multiplayer testing without an external router. When MMO mode is
 enabled the host hub tunnels frames to the world router so remote
 players share the same simulated network.
 
+
+## sshd
+
+A minimal SSH-like daemon can be started from TypeScript using
+`startSshd(kernel, { port: 22 })`. Each connection is given its own
+pseudo-terminal and spawns `/bin/bash` inside the VM. Any username and
+password are currently accepted. Once running you can connect from the
+kernel's TCP stack or a host client:
+
+```bash
+ssh -p 22 localhost
+```
+
+This opens an interactive shell just like the main terminal.
+


### PR DESCRIPTION
## Summary
- add PTY-backed sshd service
- create ssh localhost example
- document sshd usage

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684aef3416dc8324b9cef6d6653a7726