### PR TITLE
Implement basic HTTP server with file serving

### DIFF
--- a/core/services/http.test.ts
+++ b/core/services/http.test.ts
@@ -1,0 +1,28 @@
+import assert from "assert";
+import { describe, it } from "vitest";
+import * as hostfs from "fs/promises";
+import { InMemoryFileSystem } from "../fs";
+import { kernelTest } from "../kernel";
+import { startHttpd } from "./http";
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+describe("HTTP service", () => {
+    it("serves index.html", async () => {
+        await hostfs.mkdir("/var/www", { recursive: true });
+        await hostfs.writeFile("/var/www/index.html", "hello world");
+        const kernel = kernelTest!.createKernel(new InMemoryFileSystem());
+        startHttpd(kernel, { port: 8080 });
+        const conn = (kernel as any).state.tcp.connect("127.0.0.1", 8080);
+        let resp = "";
+        conn.onData((d) => {
+            resp += dec.decode(d);
+        });
+        conn.write(enc.encode("GET /index.html HTTP/1.1\r\nHost: localhost\r\n\r\n"));
+        await new Promise((r) => setTimeout(r, 10));
+        assert(resp.includes("200 OK"), "status 200");
+        assert(resp.includes("hello world"), "body served");
+        await hostfs.rm("/var/www/index.html");
+    });
+});

--- a/core/services/http.ts
+++ b/core/services/http.ts
@@ -1,18 +1,110 @@
 import { Kernel, TcpConnection } from "../kernel";
+import * as fs from "fs/promises";
+import { join, normalize } from "path";
+
+export interface HttpRequest {
+    method: string;
+    path: string;
+    version: string;
+    headers: Record<string, string>;
+}
 
 export interface HttpOptions {
     port?: number;
+    root?: string;
+    handler?: (req: HttpRequest, conn: TcpConnection) => void | Promise<void>;
 }
 
 export function startHttpd(kernel: Kernel, opts: HttpOptions = {}): void {
     const port = opts.port ?? 80;
+    const root = opts.root ?? "/var/www";
+    const enc = new TextEncoder();
+    const dec = new TextDecoder();
+
+    const defaultHandler = async (req: HttpRequest, conn: TcpConnection) => {
+        if (req.method !== "GET" && req.method !== "HEAD") {
+            const body = "Not Implemented";
+            const headers = [
+                "HTTP/1.1 501 Not Implemented",
+                `Content-Length: ${body.length}`,
+                "Connection: close",
+                "",
+                "",
+            ].join("\r\n");
+            conn.write(enc.encode(headers));
+            if (req.method === "GET") conn.write(enc.encode(body));
+            return;
+        }
+
+        const clean = req.path.split("?")[0] || "/";
+        const filePath = clean === "/" ? "/index.html" : clean;
+        const full = normalize(join(root, "." + filePath));
+        if (!full.startsWith(normalize(root))) {
+            const body = "Forbidden";
+            const headers = [
+                "HTTP/1.1 403 Forbidden",
+                `Content-Length: ${body.length}`,
+                "Connection: close",
+                "",
+                "",
+            ].join("\r\n");
+            conn.write(enc.encode(headers));
+            if (req.method === "GET") conn.write(enc.encode(body));
+            return;
+        }
+
+        try {
+            const data = await fs.readFile(full);
+            const headers = [
+                "HTTP/1.1 200 OK",
+                `Content-Length: ${data.length}`,
+                "Connection: keep-alive",
+                "",
+                "",
+            ].join("\r\n");
+            conn.write(enc.encode(headers));
+            if (req.method === "GET") conn.write(data);
+        } catch {
+            const body = "Not Found";
+            const headers = [
+                "HTTP/1.1 404 Not Found",
+                `Content-Length: ${body.length}`,
+                "Connection: close",
+                "",
+                "",
+            ].join("\r\n");
+            conn.write(enc.encode(headers));
+            if (req.method === "GET") conn.write(enc.encode(body));
+        }
+    };
+
+    const handler = opts.handler ?? defaultHandler;
+
     kernel.registerService(`httpd:${port}`, port, "tcp", {
         onConnect(conn: TcpConnection) {
+            let buffer = "";
             conn.onData((data) => {
-                void new TextDecoder().decode(data);
-                const response = `HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\nHello from Helios HTTP on port ${port}\n`;
-                conn.write(new TextEncoder().encode(response));
+                buffer += dec.decode(data);
+                processBuffer();
             });
+
+            function processBuffer() {
+                while (true) {
+                    const idx = buffer.indexOf("\r\n\r\n");
+                    if (idx === -1) break;
+                    const raw = buffer.slice(0, idx);
+                    buffer = buffer.slice(idx + 4);
+                    const lines = raw.split("\r\n");
+                    const [method, path, version] = lines[0].split(" ");
+                    const headers: Record<string, string> = {};
+                    for (let i = 1; i < lines.length; i++) {
+                        const [key, ...rest] = lines[i].split(":");
+                        headers[key.trim().toLowerCase()] = rest.join(":").trim();
+                    }
+                    const req: HttpRequest = { method, path, version, headers };
+                    void Promise.resolve(handler(req, conn));
+                }
+            }
         },
     });
 }


### PR DESCRIPTION
## Summary
- implement an HTTP/1.1 parser and simple file server in `startHttpd`
- allow custom handlers and default to serving files from `/var/www`
- add integration test for fetching `/index.html`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684af54e990c8324908a290fa2c13a9a