### PR TITLE
Add FTP service with active-mode transfers

### DIFF
--- a/core/services/ftp.test.ts
+++ b/core/services/ftp.test.ts
@@ -1,0 +1,54 @@
+import assert from "assert";
+import { describe, it } from "vitest";
+import { TCP } from "../net/tcp";
+import { InMemoryFileSystem } from "../fs";
+import { kernelTest } from "../kernel";
+import { startFtpd } from "./ftp";
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+describe("FTP service", () => {
+    it("transfers a file between kernels", async () => {
+        const k1 = kernelTest!.createKernel(new InMemoryFileSystem());
+        const k2 = kernelTest!.createKernel(new InMemoryFileSystem());
+        const shared = new TCP();
+        kernelTest!.getState(k1).tcp = shared;
+        kernelTest!.getState(k2).tcp = shared;
+
+        const fs1 = kernelTest!.getState(k1).fs as InMemoryFileSystem;
+        fs1.createDirectory("/srv", 0o755);
+        fs1.createFile("/srv/hello.txt", "hi", 0o644);
+
+        startFtpd(k1, { port: 2121, root: "/srv" });
+
+        let data = "";
+        kernelTest!.getState(k2).tcp.listen(2020, (conn) => {
+            conn.onData((d) => {
+                data += dec.decode(d);
+            });
+        });
+
+        const ctl = shared.connect("127.0.0.1", 2121);
+        ctl.write(enc.encode("USER a\r\n"));
+        ctl.write(enc.encode("PASS b\r\n"));
+        ctl.write(enc.encode("PORT 127,0,0,1,7,228\r\n"));
+        ctl.write(enc.encode("RETR hello.txt\r\n"));
+
+        await new Promise((r) => setTimeout(r, 20));
+        assert.strictEqual(data, "hi", "retrieved file contents");
+
+        let storConn: any = null;
+        kernelTest!.getState(k2).tcp.listen(2021, (conn) => {
+            storConn = conn;
+        });
+        ctl.write(enc.encode("PORT 127,0,0,1,7,229\r\n"));
+        ctl.write(enc.encode("STOR upload.txt\r\n"));
+        await new Promise((r) => setTimeout(r, 5));
+        storConn.write(enc.encode("bye"));
+        await new Promise((r) => setTimeout(r, 20));
+        const uploaded = await fs1.read("/srv/upload.txt");
+        assert.strictEqual(dec.decode(uploaded), "bye", "stored file contents");
+    });
+});
+

--- a/core/services/ftp.ts
+++ b/core/services/ftp.ts
@@ -1,0 +1,136 @@
+import { Kernel, TcpConnection } from "../kernel";
+import type { AsyncFileSystem } from "../fs/async";
+
+export interface FtpOptions {
+    port?: number;
+    root?: string;
+}
+
+const MAX_BYTES = 10 * 1024 * 1024;
+
+export function startFtpd(kernel: Kernel, opts: FtpOptions = {}): void {
+    const port = opts.port ?? 21;
+    const root = opts.root ?? "/";
+    const enc = new TextEncoder();
+    const dec = new TextDecoder();
+    const fs = kernel.state.fs as AsyncFileSystem;
+
+    function resolve(p: string): string {
+        const base = root.endsWith("/") ? root.slice(0, -1) : root;
+        if (p.startsWith("/")) return base + p;
+        return base + "/" + p;
+    }
+
+    kernel.registerService(`ftpd:${port}`, port, "tcp", {
+        onConnect(conn: TcpConnection) {
+            let buffer = "";
+            let dataIp: string | null = null;
+            let dataPort: number | null = null;
+
+            conn.write(enc.encode("220 Helios FTP\r\n"));
+            conn.onData((d) => {
+                buffer += dec.decode(d);
+                void processBuffer();
+            });
+
+            async function processBuffer() {
+                while (true) {
+                    const idx = buffer.indexOf("\r\n");
+                    if (idx === -1) break;
+                    const line = buffer.slice(0, idx);
+                    buffer = buffer.slice(idx + 2);
+                    await handle(line.trim());
+                }
+            }
+
+            async function handle(line: string) {
+                const [cmd, ...rest] = line.split(" ");
+                const arg = rest.join(" ");
+                switch (cmd.toUpperCase()) {
+                    case "USER":
+                        conn.write(enc.encode("331 OK\r\n"));
+                        break;
+                    case "PASS":
+                        conn.write(enc.encode("230 Logged in\r\n"));
+                        break;
+                    case "PORT": {
+                        const nums = arg.split(",").map((n) => parseInt(n, 10));
+                        if (nums.length === 6) {
+                            dataIp = nums.slice(0, 4).join(".");
+                            dataPort = (nums[4] << 8) | nums[5];
+                            conn.write(enc.encode("200 PORT OK\r\n"));
+                        } else {
+                            conn.write(enc.encode("501 Bad PORT\r\n"));
+                        }
+                        break;
+                    }
+                    case "LIST": {
+                        if (!dataIp || dataPort === null) {
+                            conn.write(enc.encode("425 Use PORT first\r\n"));
+                            break;
+                        }
+                        try {
+                            const path = resolve(arg || ".");
+                            const list = await fs.readdir(path);
+                            const names = list.map((n) => n.path.split("/").pop()).join("\r\n");
+                            const dataConn = kernel.state.tcp.connect(dataIp, dataPort);
+                            dataConn.write(enc.encode(names + "\r\n"));
+                            conn.write(enc.encode("226 Transfer complete\r\n"));
+                        } catch {
+                            conn.write(enc.encode("550 Failed to list\r\n"));
+                        }
+                        break;
+                    }
+                    case "RETR": {
+                        if (!dataIp || dataPort === null) {
+                            conn.write(enc.encode("425 Use PORT first\r\n"));
+                            break;
+                        }
+                        try {
+                            const data = await fs.read(resolve(arg));
+                            const slice = data.slice(0, MAX_BYTES);
+                            const dataConn = kernel.state.tcp.connect(dataIp, dataPort);
+                            dataConn.write(slice);
+                            conn.write(enc.encode("226 Transfer complete\r\n"));
+                        } catch {
+                            conn.write(enc.encode("550 Failed to open file\r\n"));
+                        }
+                        break;
+                    }
+                    case "STOR": {
+                        if (!dataIp || dataPort === null) {
+                            conn.write(enc.encode("425 Use PORT first\r\n"));
+                            break;
+                        }
+                        const filePath = resolve(arg);
+                        await fs.open(filePath, "w");
+                        const chunks: Uint8Array[] = [];
+                        let size = 0;
+                        const dataConn = kernel.state.tcp.connect(dataIp, dataPort);
+                        dataConn.onData((chunk) => {
+                            if (size >= MAX_BYTES) return;
+                            const available = Math.min(MAX_BYTES - size, chunk.length);
+                            chunks.push(chunk.slice(0, available));
+                            size += available;
+                        });
+                        await new Promise((r) => setTimeout(r, 10));
+                        const total = size;
+                        const buf = new Uint8Array(total);
+                        let offset = 0;
+                        for (const c of chunks) {
+                            buf.set(c, offset);
+                            offset += c.length;
+                        }
+                        await fs.write(filePath, buf);
+                        conn.write(enc.encode("226 Transfer complete\r\n"));
+                        break;
+                    }
+                    default:
+                        conn.write(enc.encode("502 Command not implemented\r\n"));
+                }
+            }
+        },
+    });
+}
+
+

--- a/core/services/index.ts
+++ b/core/services/index.ts
@@ -1,3 +1,4 @@
 export * from "./http";
 export * from "./ssh";
 export * from "./ping";
+export * from "./ftp";

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,5 +12,6 @@ This folder contains detailed guides covering each part of the project. Use the 
 - [Developer Workflow](workflow.md)
 - [GUI, Shell and Sandbox Roadmap](gui_shell_sandbox.md)
 - [Networking Example](network_example.md)
+- [FTP Example](ftp_example.md)
 - [Networking Tools](networking.md)
 - [Contributor Guide](../CONTRIBUTING.md)

--- a/docs/ftp_example.md
+++ b/docs/ftp_example.md
@@ -1,0 +1,18 @@
+# FTP Example
+
+This short guide demonstrates transferring a file using the built-in FTP daemon.
+
+1. Start the server on one VM:
+
+```ts
+import { startFtpd } from "../core/services/ftp";
+
+startFtpd(kernel, { port: 2121 });
+```
+
+2. From another VM connect using an FTP client and enable active mode. After
+sending `USER`, `PASS` and `PORT`, issue `RETR foo.txt` or `STOR bar.txt` to
+transfer files.
+
+Routing between instances must be configured so the data connection reaches the
+client.


### PR DESCRIPTION
## Summary
- implement `startFtpd` daemon for active-mode FTP
- export ftp service in index
- document FTP usage and add an example
- test transferring files between kernels

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684af762ad4483249ed47456e209726b