### PR TITLE
Add proof-of-work coin service

### DIFF
--- a/apps/examples/coin.ts
+++ b/apps/examples/coin.ts
@@ -1,0 +1,10 @@
+import { Kernel } from "../../core/kernel";
+import { startCoinService } from "../../core/services/coin";
+
+export async function runCoinExample(kernel: Kernel) {
+    const coin = startCoinService(kernel, { port: 6000, difficulty: 2, peers: [] });
+    setInterval(() => {
+        const block = coin.mine(`block ${Date.now()}`);
+        console.log(`mined block ${block.hash}`);
+    }, 5000);
+}

--- a/core/services/coin.test.ts
+++ b/core/services/coin.test.ts
@@ -1,0 +1,58 @@
+import assert from "assert";
+import { describe, it } from "vitest";
+import { InMemoryFileSystem } from "../fs";
+import { kernelTest } from "../kernel";
+import { UDP } from "../net/udp";
+import { startCoinService } from "./coin";
+
+describe("Coin service", () => {
+    it("consensus across kernels", async () => {
+        const udp = new UDP();
+        const k1 = kernelTest!.createKernel(new InMemoryFileSystem());
+        const k2 = kernelTest!.createKernel(new InMemoryFileSystem());
+        const k3 = kernelTest!.createKernel(new InMemoryFileSystem());
+        kernelTest!.getState(k1).udp = udp;
+        kernelTest!.getState(k2).udp = udp;
+        kernelTest!.getState(k3).udp = udp;
+
+        const s1 = startCoinService(k1, {
+            port: 4001,
+            peers: [
+                { ip: "127.0.0.1", port: 4002 },
+                { ip: "127.0.0.1", port: 4003 },
+            ],
+            difficulty: 1,
+        });
+        const s2 = startCoinService(k2, {
+            port: 4002,
+            peers: [
+                { ip: "127.0.0.1", port: 4001 },
+                { ip: "127.0.0.1", port: 4003 },
+            ],
+            difficulty: 1,
+        });
+        const s3 = startCoinService(k3, {
+            port: 4003,
+            peers: [
+                { ip: "127.0.0.1", port: 4001 },
+                { ip: "127.0.0.1", port: 4002 },
+            ],
+            difficulty: 1,
+        });
+
+        await new Promise((r) => setTimeout(r, 10));
+
+        s1.mine("one");
+        await new Promise((r) => setTimeout(r, 20));
+        s1.mine("two");
+        await new Promise((r) => setTimeout(r, 20));
+        s1.mine("three");
+        await new Promise((r) => setTimeout(r, 50));
+
+        assert.strictEqual(s1.chain.length, 4);
+        assert.strictEqual(s2.chain.length, 4);
+        assert.strictEqual(s3.chain.length, 4);
+        assert.strictEqual(s1.chain[3].hash, s2.chain[3].hash);
+        assert.strictEqual(s1.chain[3].hash, s3.chain[3].hash);
+    });
+});

--- a/core/services/coin.ts
+++ b/core/services/coin.ts
@@ -1,0 +1,142 @@
+import { createHash } from "node:crypto";
+import { Kernel, UdpConnection } from "../kernel";
+
+export interface CoinOptions {
+    port?: number;
+    peers?: Array<{ ip: string; port: number }>;
+    difficulty?: number;
+}
+
+export interface Block {
+    index: number;
+    prevHash: string;
+    timestamp: number;
+    data: string;
+    nonce: number;
+    hash: string;
+}
+
+export function startCoinService(kernel: Kernel, opts: CoinOptions = {}) {
+    const port = opts.port ?? 3333;
+    const peers = opts.peers ?? [];
+    const difficulty = opts.difficulty ?? 1;
+    const enc = new TextEncoder();
+    const dec = new TextDecoder();
+    const prefix = "0".repeat(difficulty);
+
+    const genesis: Block = {
+        index: 0,
+        prevHash: "0",
+        timestamp: 0,
+        data: "genesis",
+        nonce: 0,
+        hash: createHash("sha256")
+            .update("0" + "0" + "genesis" + 0)
+            .digest("hex"),
+    };
+
+    const chain: Block[] = [genesis];
+    const conns: UdpConnection[] = [];
+
+    function calcHash(prevHash: string, ts: number, data: string, nonce: number) {
+        return createHash("sha256")
+            .update(`${prevHash}${ts}${data}${nonce}`)
+            .digest("hex");
+    }
+
+    function verifyBlock(block: Block, prev: Block): boolean {
+        const h = calcHash(prev.hash, block.timestamp, block.data, block.nonce);
+        return (
+            block.hash === h &&
+            block.prevHash === prev.hash &&
+            block.index === prev.index + 1 &&
+            block.hash.startsWith(prefix)
+        );
+    }
+
+    function verifyChain(ch: Block[]): boolean {
+        if (ch.length === 0 || ch[0].hash !== genesis.hash) return false;
+        for (let i = 1; i < ch.length; i++) {
+            if (!verifyBlock(ch[i], ch[i - 1])) return false;
+        }
+        return true;
+    }
+
+    function addBlock(block: Block): boolean {
+        const prev = chain[chain.length - 1];
+        if (!verifyBlock(block, prev)) return false;
+        chain.push(block);
+        return true;
+    }
+
+    function broadcast(msg: unknown) {
+        const data = enc.encode(JSON.stringify(msg));
+        for (const c of conns) c.write(data);
+    }
+
+    function handle(conn: UdpConnection, raw: Uint8Array) {
+        try {
+            const msg = JSON.parse(dec.decode(raw));
+            if (msg.type === "request_chain") {
+                conn.write(enc.encode(JSON.stringify({ type: "chain", chain })));
+            } else if (msg.type === "chain" && Array.isArray(msg.chain)) {
+                if (msg.chain.length > chain.length && verifyChain(msg.chain)) {
+                    chain.length = 0;
+                    chain.push(...msg.chain);
+                }
+            } else if (msg.type === "block" && msg.block) {
+                const added = addBlock(msg.block as Block);
+                if (added) broadcast({ type: "block", block: msg.block });
+                else conn.write(enc.encode(JSON.stringify({ type: "request_chain" })));
+            }
+        } catch {}
+    }
+
+    kernel.registerService(`coind:${port}`, port, "udp", {
+        onConnect(conn) {
+            conn.onData((d) => handle(conn, d));
+        },
+    });
+
+    function connectPeers() {
+        for (const p of peers) {
+            const conn = kernel.state.udp.connect(p.ip, p.port);
+            conns.push(conn);
+            conn.onData((d) => handle(conn, d));
+            conn.write(enc.encode(JSON.stringify({ type: "request_chain" })));
+        }
+    }
+
+    setTimeout(connectPeers, 1);
+
+    function mine(data: string): Block {
+        const prev = chain[chain.length - 1];
+        let nonce = 0;
+        let ts = Date.now();
+        let hash = "";
+        while (true) {
+            hash = calcHash(prev.hash, ts, data, nonce);
+            if (hash.startsWith(prefix)) break;
+            nonce++;
+            ts = Date.now();
+        }
+        const block: Block = {
+            index: prev.index + 1,
+            prevHash: prev.hash,
+            timestamp: ts,
+            data,
+            nonce,
+            hash,
+        };
+        chain.push(block);
+        broadcast({ type: "block", block });
+        return block;
+    }
+
+    return {
+        mine,
+        get chain() {
+            return chain;
+        },
+    };
+}

--- a/core/services/index.ts
+++ b/core/services/index.ts
@@ -4,3 +4,4 @@ export * from "./ping";
 export * from "./ftp";
 export * from "./smtp";
 export * from "./imap";
+export * from "./coin";


### PR DESCRIPTION
## Summary
- implement `core/services/coin.ts` with simple blockchain and hashcash proof-of-work
- broadcast mined blocks over UDP gossip and sync chains
- export the coin service
- add example CLI that runs the coin service
- test consensus of three kernels

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684afbc75a0483249667cd7a4467a321