### PR TITLE
Add service tests and reload on restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,12 @@ while (true) {
 
 Kernel denies undeclared syscalls.
 
+Command line wrappers simplify running the built-in daemons. Use
+`httpd`, `ftpd`, `ssh` or `smtp` to start the respective services from
+the shell. The `sendmail` and `mail` tools talk to the SMTP/IMAP
+servers, while the coin example demonstrates a basic peer started with
+`startCoinService`.
+
 ---
 
 ## 7 — Security Model

--- a/core/kernel/index.ts
+++ b/core/kernel/index.ts
@@ -74,6 +74,9 @@ import {
     startPingService,
     startSmtpd,
     startImapd,
+    startFtpd,
+    startNamed,
+    startCoinService,
 } from "../services";
 import {
     ProcessID,
@@ -449,6 +452,12 @@ export class Kernel {
                 startSshd(kernel, { port: svc.port });
             } else if (name.startsWith("pingd")) {
                 startPingService(kernel, { port: svc.port });
+            } else if (name.startsWith("ftpd")) {
+                startFtpd(kernel, { port: svc.port });
+            } else if (name.startsWith("named")) {
+                void startNamed(kernel, { port: svc.port });
+            } else if (name.startsWith("coind")) {
+                startCoinService(kernel, { port: svc.port });
             } else if (name.startsWith("smtpd")) {
                 startSmtpd(kernel, { port: svc.port });
             } else if (name.startsWith("imapd")) {

--- a/core/services/imap.test.ts
+++ b/core/services/imap.test.ts
@@ -1,0 +1,41 @@
+import assert from "assert";
+import { describe, it } from "vitest";
+import { InMemoryFileSystem } from "../fs";
+import { kernelTest } from "../kernel";
+import { TCP } from "../net/tcp";
+import { startImapd } from "./imap";
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+describe("IMAP service", () => {
+    it("lists and retrieves mail", async () => {
+        const k1 = kernelTest!.createKernel(new InMemoryFileSystem());
+        const k2 = kernelTest!.createKernel(new InMemoryFileSystem());
+        const tcp = new TCP();
+        kernelTest!.getState(k1).tcp = tcp;
+        kernelTest!.getState(k2).tcp = tcp;
+
+        const fs1 = kernelTest!.getState(k1).fs as InMemoryFileSystem;
+        fs1.createDirectory("/var", 0o755);
+        fs1.createDirectory("/var/mail", 0o755);
+        fs1.createDirectory("/var/mail/bob", 0o755);
+        fs1.createFile("/var/mail/bob/msg.txt", "hello", 0o644);
+
+        startImapd(k1, { port: 2143 });
+
+        const conn = tcp.connect("127.0.0.1", 2143);
+        let buf = "";
+        conn.onData((d) => {
+            buf += dec.decode(d);
+        });
+
+        conn.write(enc.encode("LIST bob\r\n"));
+        await new Promise((r) => setTimeout(r, 10));
+        assert(buf.includes("msg.txt"), "LIST output");
+        buf = "";
+        conn.write(enc.encode("RETR bob msg.txt\r\n"));
+        await new Promise((r) => setTimeout(r, 10));
+        assert(buf.includes("hello"), "RETR output");
+    });
+});

--- a/core/services/ping.test.ts
+++ b/core/services/ping.test.ts
@@ -1,0 +1,30 @@
+import assert from "assert";
+import { describe, it } from "vitest";
+import { InMemoryFileSystem } from "../fs";
+import { kernelTest } from "../kernel";
+import { UDP } from "../net/udp";
+import { startPingService } from "./ping";
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+describe("Ping service", () => {
+    it("echoes UDP packets", async () => {
+        const udp = new UDP();
+        const k1 = kernelTest!.createKernel(new InMemoryFileSystem());
+        const k2 = kernelTest!.createKernel(new InMemoryFileSystem());
+        kernelTest!.getState(k1).udp = udp;
+        kernelTest!.getState(k2).udp = udp;
+
+        startPingService(k1, { port: 9999 });
+
+        const conn = udp.connect("127.0.0.1", 9999);
+        let resp = "";
+        conn.onData((d) => {
+            resp += dec.decode(d);
+        });
+        conn.write(enc.encode("hi"));
+        await new Promise((r) => setTimeout(r, 10));
+        assert.strictEqual(resp, "hi");
+    });
+});

--- a/core/services/ssh.test.ts
+++ b/core/services/ssh.test.ts
@@ -1,0 +1,42 @@
+import assert from "assert";
+import { describe, it } from "vitest";
+import { InMemoryFileSystem } from "../fs";
+import { kernelTest } from "../kernel";
+import { TCP } from "../net/tcp";
+import { startSshd } from "./ssh";
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+describe("SSH service", () => {
+    it("spawns a shell after login", async () => {
+        const tcp = new TCP();
+        const k1 = kernelTest!.createKernel(new InMemoryFileSystem());
+        const k2 = kernelTest!.createKernel(new InMemoryFileSystem());
+        kernelTest!.getState(k1).tcp = tcp;
+        kernelTest!.getState(k2).tcp = tcp;
+
+        let spawned = false;
+        (k1 as any).spawn = async () => {
+            spawned = true;
+            return 0;
+        };
+
+        startSshd(k1, { port: 2222 });
+
+        const conn = tcp.connect("127.0.0.1", 2222);
+        let buf = "";
+        conn.onData((d) => {
+            buf += dec.decode(d);
+        });
+
+        await new Promise((r) => setTimeout(r, 50));
+        conn.write(enc.encode("user\n"));
+        await new Promise((r) => setTimeout(r, 20));
+        conn.write(enc.encode("pass\n"));
+        await new Promise((r) => setTimeout(r, 50));
+
+        assert(spawned, "spawn called");
+    });
+});
+

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -56,7 +56,8 @@ supported and uploads/downloads are limited to a few megabytes.
 ## smtp
 
 `smtp [port] [root]` runs the simple mail daemon described below which
-stores incoming messages under `/var/mail`.
+stores incoming messages under `/var/mail`. Use `sendmail` to submit
+messages and `mail` to read them via the IMAP interface.
 
 ## Host hub communication
 
@@ -70,8 +71,8 @@ players share the same simulated network.
 
 ## sshd
 
-A minimal SSH-like daemon can be started from TypeScript using
-`startSshd(kernel, { port: 22 })`. Each connection is given its own
+The `ssh` command starts a minimal SSH-like daemon, equivalent to
+calling `startSshd(kernel, { port: 22 })` from TypeScript. Each connection is given its own
 pseudo-terminal and spawns `/bin/bash` inside the VM. Any username and
 password are currently accepted. Once running you can connect from the
 kernel's TCP stack or a host client:
@@ -104,4 +105,11 @@ QUIT
 
 The bundled `sendmail` and `mail` CLI utilities wrap these protocols for quick
 testing.
+
+
+## coin
+
+The peer-to-peer coin daemon is started with `startCoinService(kernel, { port: 3333 })`.
+Blocks are exchanged over UDP and mined with a simple proof-of-work. A
+small example program resides under `apps/examples/coin.ts`.
 


### PR DESCRIPTION
## Summary
- test ping, imap and ssh daemons
- reload ftp, DNS and coin services when restoring snapshots
- document CLI usage for network daemons in README and docs

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684b03bbf75c832495316ee2f8f1f3c9