### PR TITLE
Add idle scheduler backoff

### DIFF
--- a/core/kernel/syscalls.ts
+++ b/core/kernel/syscalls.ts
@@ -430,6 +430,7 @@ export async function syscall_spawn(
     pcb.spawnOpts = { ...opts };
     pcb.argv = opts.argv ?? [];
     this.readyQueue.push(pcb);
+    (this as any).idleDelay = (this as any).baseIdleDelay;
     if (code === BASH_SOURCE) {
         eventBus.emit("boot.shellReady", { pid });
     }


### PR DESCRIPTION
## Summary
- implement exponential delay for scheduler when idle
- reset delay when new processes spawn

## Testing
- `pnpm test`
- attempted to run `npx tsx idleCpu.ts` to observe idle CPU usage, but environment lacks full runtime so process exited quickly

------
https://chatgpt.com/codex/tasks/task_e_684b15296d148324947b3e84c0a45b7b