### PR TITLE
Reduce SSH polling with async PTY wait

### DIFF
--- a/core/kernel/index.ts
+++ b/core/kernel/index.ts
@@ -100,6 +100,7 @@ import {
     createSyscallDispatcher,
     syscall_open,
     syscall_read,
+    syscall_wait,
     syscall_write,
     syscall_close,
     syscall_spawn,
@@ -230,6 +231,7 @@ export class Kernel {
     public createSyscallDispatcher = createSyscallDispatcher;
     private syscall_open = syscall_open;
     private syscall_read = syscall_read;
+    private syscall_wait = syscall_wait;
     private syscall_write = syscall_write;
     private syscall_close = syscall_close;
     private syscall_spawn = syscall_spawn;
@@ -823,6 +825,11 @@ export const kernelTest =
                   fd: FileDescriptor,
                   len: number,
               ) => syscall_read.call(k, pcb, fd, len),
+              syscall_wait: (
+                  k: Kernel,
+                  pcb: ProcessControlBlock,
+                  fd: FileDescriptor,
+              ) => syscall_wait.call(k, pcb, fd),
               syscall_draw: (
                   k: Kernel,
                   pcb: ProcessControlBlock,

--- a/core/kernel/tty.ts
+++ b/core/kernel/tty.ts
@@ -3,6 +3,8 @@ export type TtySide = "master" | "slave";
 class Pty {
     public masterBuffer: number[] = [];
     public slaveBuffer: number[] = [];
+    public masterWaiters: Array<() => void> = [];
+    public slaveWaiters: Array<() => void> = [];
     constructor(public id: number) {}
 }
 
@@ -25,7 +27,13 @@ export class PtyManager {
         const pty = this.ptys.get(id);
         if (!pty) return;
         const target = side === "master" ? pty.slaveBuffer : pty.masterBuffer;
+        const waiters =
+            side === "master" ? pty.slaveWaiters : pty.masterWaiters;
         for (const b of data) target.push(b);
+        while (waiters.length > 0) {
+            const w = waiters.shift();
+            if (w) w();
+        }
     }
 
     read(id: number, side: TtySide, length: number): Uint8Array {
@@ -34,5 +42,17 @@ export class PtyManager {
         const buf = side === "master" ? pty.masterBuffer : pty.slaveBuffer;
         const out: number[] = buf.splice(0, length);
         return Uint8Array.from(out);
+    }
+
+    wait(id: number, side: TtySide): Promise<void> {
+        const pty = this.ptys.get(id);
+        if (!pty) return Promise.resolve();
+        const buf = side === "master" ? pty.masterBuffer : pty.slaveBuffer;
+        if (buf.length > 0) return Promise.resolve();
+        return new Promise((resolve) => {
+            const waiters =
+                side === "master" ? pty.masterWaiters : pty.slaveWaiters;
+            waiters.push(resolve);
+        });
     }
 }


### PR DESCRIPTION
## Summary
- add wait capability to `PtyManager`
- expose new `wait` syscall and kernel helpers
- use `wait` in ssh program instead of polling

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684b161fb9748324b554ac32157ad278