### PR TITLE
Add high-contrast theme

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -12,3 +12,15 @@ themes select <name>
 
 The choice is stored in `/etc/theme` and read by the desktop program on startup.
 
+
+## Built-in example
+
+A colour-blind friendly high-contrast theme is provided at `ui/themes/high-contrast.css`.
+Copy this file and a `wallpaper.jpg` into `/opt/themes/high-contrast/` then run:
+
+```sh
+themes select high-contrast
+```
+
+The palette uses WCAG compliant contrast ratios.
+

--- a/ui/themes/high-contrast.css
+++ b/ui/themes/high-contrast.css
@@ -1,0 +1,28 @@
+/* High-Contrast theme using colour-blind safe palette */
+.window-container {
+    background-color: #000;
+    color: #fff;
+    border: 2px solid #fff;
+}
+.window-title-bar {
+    background: #000;
+    color: #fff;
+    border-bottom: 2px solid #fff;
+}
+.window-button:nth-child(1) { background-color: #D55E00; } /* Close */
+.window-button:nth-child(2) { background-color: #F0E442; } /* Minimize */
+.window-button:nth-child(3) { background-color: #009E73; } /* Maximize */
+.monitor-select {
+    background-color: #000;
+    color: #fff;
+    border: 2px solid #fff;
+}
+.window-content {
+    background-color: #000;
+    color: #fff;
+}
+.crash-overlay {
+    background: rgba(0, 0, 0, 0.85);
+    color: #fff;
+}
+


### PR DESCRIPTION
## Summary
- add `ui/themes/high-contrast.css` offering a colour-blind friendly palette
- document how to enable the new theme via `themes select`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684b3c9c0b8c8324ae34084add84d43d