### PR TITLE
Fix duplicate returns in ulimit

### DIFF
--- a/apps/cli/programs/ulimit.ts
+++ b/apps/cli/programs/ulimit.ts
@@ -4,7 +4,7 @@ export async function main(syscall: SyscallDispatcher, argv: string[]): Promise<
     const STDOUT_FD = 1;
     const encode = (s: string) => new TextEncoder().encode(s);
 
-    let result = 0;
+    const result = 0;
 
     if (argv.length === 0) {
         const res = await syscall('set_quota');

--- a/apps/cli/programs/ulimit.ts
+++ b/apps/cli/programs/ulimit.ts
@@ -4,6 +4,8 @@ export async function main(syscall: SyscallDispatcher, argv: string[]): Promise<
     const STDOUT_FD = 1;
     const encode = (s: string) => new TextEncoder().encode(s);
 
+    let result = 0;
+
     if (argv.length === 0) {
         const res = await syscall('set_quota');
         await syscall(
@@ -11,24 +13,23 @@ export async function main(syscall: SyscallDispatcher, argv: string[]): Promise<
             STDOUT_FD,
             encode('cpu ' + res.quotaMs + ' total ' + res.quotaMs_total + ' mem ' + res.quotaMem + '\n'),
         );
-        return 0;
-    }
-
-    let ms: number | undefined;
-    let mem: number | undefined;
-    let total: number | undefined;
-    for (let i = 0; i < argv.length; i++) {
-        if (argv[i] === '-t') {
-            ms = parseInt(argv[i + 1] || '0', 10);
-            i++;
-        } else if (argv[i] === '-m') {
-            mem = parseInt(argv[i + 1] || '0', 10);
-            i++;
-        } else if (argv[i] === '-T') {
-            total = parseInt(argv[i + 1] || '0', 10);
-            i++;
+    } else {
+        let ms: number | undefined;
+        let mem: number | undefined;
+        let total: number | undefined;
+        for (let i = 0; i < argv.length; i++) {
+            if (argv[i] === '-t') {
+                ms = parseInt(argv[i + 1] || '0', 10);
+                i++;
+            } else if (argv[i] === '-m') {
+                mem = parseInt(argv[i + 1] || '0', 10);
+                i++;
+            } else if (argv[i] === '-T') {
+                total = parseInt(argv[i + 1] || '0', 10);
+                i++;
+            }
         }
+        await syscall('set_quota', ms, mem, total);
     }
-    await syscall('set_quota', ms, mem, total);
-    return 0;
+    return result;
 }


### PR DESCRIPTION
## Summary
- refactor `ulimit` CLI command to use a single return statement

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684b45d5cf9c8324affa694e9353cea7