### PR TITLE
Fix kernel boot/shutdown error handling

### DIFF
--- a/core/fs/sqlite.ts
+++ b/core/fs/sqlite.ts
@@ -10,12 +10,11 @@ export async function loadSnapshot(): Promise<FileSystemSnapshot | null> {
     }
 }
 
-export async function persistSnapshot(snapshot: FileSystemSnapshot) {
-    try {
-        await invoke("save_fs", { json: JSON.stringify(snapshot) });
-    } catch {
-        // ignore
-    }
+export async function persistSnapshot(
+    snapshot: FileSystemSnapshot,
+): Promise<void> {
+    if (typeof window === "undefined") return;
+    await invoke("save_fs", { json: JSON.stringify(snapshot) });
 }
 
 export function createPersistHook(): PersistHook {
@@ -34,12 +33,9 @@ export async function loadKernelSnapshot(): Promise<any | null> {
     }
 }
 
-export async function persistKernelSnapshot(snapshot: any) {
-    try {
-        await invoke("save_snapshot", { json: JSON.stringify(snapshot) });
-    } catch {
-        // ignore
-    }
+export async function persistKernelSnapshot(snapshot: any): Promise<void> {
+    if (typeof window === "undefined") return;
+    await invoke("save_snapshot", { json: JSON.stringify(snapshot) });
 }
 
 export async function saveNamedSnapshot(name: string, snapshot: any) {

--- a/core/kernel/syscalls.ts
+++ b/core/kernel/syscalls.ts
@@ -114,7 +114,7 @@ export function createSyscallDispatcher(
             case "snapshot":
                 return this.snapshot();
             case "save_snapshot":
-                persistKernelSnapshot(this.snapshot());
+                await persistKernelSnapshot(this.snapshot());
                 return 0;
             case "save_snapshot_named":
                 await saveNamedSnapshot(args[0], this.snapshot());
@@ -123,7 +123,7 @@ export function createSyscallDispatcher(
                 const snap = await loadNamedSnapshot(args[0]);
                 if (!snap) return -1;
                 this.running = false;
-                persistKernelSnapshot(snap);
+                await persistKernelSnapshot(snap);
                 eventBus.emit("system.reboot", {});
                 return 0;
             }


### PR DESCRIPTION
## Summary
- propagate errors on boot and shutdown instead of logging
- return early when not running under Tauri when persisting snapshots
- await snapshot persistence in syscalls and shutdown

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684b822197948324a582c6dddb81fedd