### PR TITLE
Add CPU quota host & kernel steps

### DIFF
--- a/tasks.md
+++ b/tasks.md
@@ -52,6 +52,8 @@ features are noted where relevant. Reference lines are cited from the repository
 ## 8. Security & Sandboxing
 - **Iframe FS isolation** – GUI apps must not read `file:///` URLs (sandbox checks).
 - **CPU quota enforcement** – kill processes stuck in infinite loops without freezing desktop.
+    - Host (Rust/Tauri): monitor wall-clock per process; send SIGXCPU on excess.
+    - Kernel: handle SIGXCPU → terminate process, log to /var/log/kernel.
 - **Package capability checks** – block native Node API usage unless granted at install time.
 - **postMessage validation** – discard messages with spoofed window IDs.
 


### PR DESCRIPTION
## Summary
- detail CPU quota enforcement tasks with host and kernel steps

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684b8650c7188324b9e42ebffe2ae214