### PR TITLE
Implement /proc mounts listing

### DIFF
--- a/core/kernel/index.ts
+++ b/core/kernel/index.ts
@@ -95,6 +95,7 @@ import {
     registerJob,
     removeJob,
     updateJobStatus,
+    updateProcMounts,
 } from "./process";
 import {
     SyscallDispatcher,
@@ -242,6 +243,7 @@ export class Kernel {
     private registerProcFd = registerProcFd;
     private removeProcFd = removeProcFd;
     private procStatus = procStatus;
+    private updateProcMounts = updateProcMounts;
     private runProcess = runProcess;
     public registerJob = registerJob;
     public removeJob = removeJob;
@@ -314,6 +316,7 @@ export class Kernel {
         eventBus.on("desktop.windowRecv", (payload) =>
             this.handleWindowMessage(payload),
         );
+        this.updateProcMounts();
     }
 
     /**

--- a/core/kernel/syscalls.ts
+++ b/core/kernel/syscalls.ts
@@ -714,10 +714,19 @@ export async function syscall_mount(
 ): Promise<number> {
     const raw = await fs.readFile(imagePath, "utf8");
     const snap = JSON.parse(raw) as FileSystemSnapshot;
+    const kernelWithVolumes = this as unknown as {
+        mountedVolumes: Map<string, string>;
+        updateProcMounts: () => void;
+    };
+    if (kernelWithVolumes.mountedVolumes.has(mountPoint)) {
+        throw new Error(`EEXIST: mount point busy, mount '${mountPoint}'`);
+    }
     await this.state.fs.mount(snap, mountPoint);
-    (
-        this as unknown as { mountedVolumes: Map<string, string> }
-    ).mountedVolumes.set(mountPoint, pathModule.resolve(imagePath));
+    kernelWithVolumes.mountedVolumes.set(
+        mountPoint,
+        pathModule.resolve(imagePath),
+    );
+    kernelWithVolumes.updateProcMounts();
     return 0;
 }
 
@@ -728,6 +737,7 @@ export async function syscall_unmount(
 ): Promise<number> {
     const kernelWithVolumes = this as unknown as {
         mountedVolumes: Map<string, string>;
+        updateProcMounts: () => void;
     };
     const file = kernelWithVolumes.mountedVolumes.get(mountPoint);
     let snap: FileSystemSnapshot | undefined;
@@ -756,6 +766,7 @@ export async function syscall_unmount(
         await fs.writeFile(file, JSON.stringify(snap), "utf8");
         kernelWithVolumes.mountedVolumes.delete(mountPoint);
     }
+    kernelWithVolumes.updateProcMounts();
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- maintain mount table in kernel
- expose mounted volumes via `/proc/mounts`
- guard /proc helpers for filesystems without virtual features
- update mount/unmount syscalls to block duplicate mounts and refresh `/proc/mounts`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684b868e55f48324a73ab5c11eeda58c