### PR TITLE
Add single-user mode kill logic

### DIFF
--- a/core/kernel/index.ts
+++ b/core/kernel/index.ts
@@ -132,6 +132,7 @@ import {
     syscall_wifi_join,
     syscall_route_add,
     syscall_route_del,
+    syscall_single_user,
 } from "./syscalls";
 import { transform } from "esbuild";
 import vm from "node:vm";
@@ -235,6 +236,7 @@ export class Kernel {
     private dhcpNextHost = 2;
     private readonly baseIdleDelay = 10;
     private idleDelay = this.baseIdleDelay;
+    private singleUser = false;
     private createProcess = createProcess;
     private cleanupProcess = cleanupProcess;
     private ensureProcRoot = ensureProcRoot;
@@ -278,6 +280,7 @@ export class Kernel {
     private syscall_dhcp_request = syscall_dhcp_request;
     private syscall_route_add = syscall_route_add;
     private syscall_route_del = syscall_route_del;
+    private syscall_single_user = syscall_single_user;
 
     private async compileWithCache(source: string, mtime: number): Promise<string> {
         const hash = createHash("sha256").update(source).digest("hex");
@@ -926,6 +929,8 @@ export const kernelTest =
                   syscall_route_add.call(k, cidr, nic),
               syscall_route_del: (k: Kernel, cidr: string) =>
                   syscall_route_del.call(k, cidr),
+              syscall_single_user: (k: Kernel, on?: boolean) =>
+                  syscall_single_user.call(k, on),
               getRouter: (k: Kernel) => (k as any).router as Router,
               addMonitor: (k: Kernel, w: number, h: number) =>
                   k.addMonitor(w, h),


### PR DESCRIPTION
## Summary
- add `singleUser` mode and `syscall_single_user`
- permit SIGTERM to PID 1 only in single-user mode
- test init kill protections

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684b854ed9508324921e45eaf19debfa