### PR TITLE
Implement service hardening

### DIFF
--- a/core/services/http.test.ts
+++ b/core/services/http.test.ts
@@ -26,6 +26,9 @@ describe("HTTP service", () => {
         await new Promise((r) => setTimeout(r, 10));
         assert(resp.includes("200 OK"), "status 200");
         assert(resp.includes("hello world"), "body served");
+        assert(resp.includes("Content-Type: text/html"));
+        const log = dec.decode(await (kernelTest!.getState(kernel).fs as InMemoryFileSystem).read("/var/log/httpd"));
+        assert(log.includes("/index.html"));
         await hostfs.rm(rootDir, { recursive: true, force: true });
     });
 });

--- a/core/services/http.ts
+++ b/core/services/http.ts
@@ -1,6 +1,7 @@
 import { Kernel, TcpConnection } from "../kernel";
 import * as fs from "fs/promises";
-import { join, normalize } from "path";
+import { join, normalize, extname } from "path";
+import type { AsyncFileSystem } from "../fs/async";
 
 export interface HttpRequest {
     method: string;
@@ -20,6 +21,37 @@ export function startHttpd(kernel: Kernel, opts: HttpOptions = {}): void {
     const root = opts.root ?? "/var/www";
     const enc = new TextEncoder();
     const dec = new TextDecoder();
+    const vfs = kernel.state.fs as AsyncFileSystem;
+
+    const mime: Record<string, string> = {
+        ".html": "text/html",
+        ".htm": "text/html",
+        ".js": "application/javascript",
+        ".json": "application/json",
+        ".css": "text/css",
+        ".txt": "text/plain",
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".gif": "image/gif",
+    };
+
+    async function log(ip: string, req: HttpRequest, status: number, size: number): Promise<void> {
+        try {
+            await vfs.mkdir("/var", 0o755);
+        } catch {}
+        try {
+            await vfs.mkdir("/var/log", 0o755);
+        } catch {}
+        const path = "/var/log/httpd";
+        await vfs.open(path, "a");
+        let prev = "";
+        try {
+            prev = dec.decode(await vfs.read(path));
+        } catch {}
+        const line = `${ip} - - [${new Date().toISOString()}] "${req.method} ${req.path} ${req.version}" ${status} ${size}\n`;
+        await vfs.write(path, enc.encode(prev + line));
+    }
 
     const defaultHandler = async (req: HttpRequest, conn: TcpConnection) => {
         if (req.method !== "GET" && req.method !== "HEAD") {
@@ -28,11 +60,13 @@ export function startHttpd(kernel: Kernel, opts: HttpOptions = {}): void {
                 "HTTP/1.1 501 Not Implemented",
                 `Content-Length: ${body.length}`,
                 "Connection: close",
+                "Content-Type: text/plain",
                 "",
                 "",
             ].join("\r\n");
             conn.write(enc.encode(headers));
             if (req.method === "GET") conn.write(enc.encode(body));
+            await log(conn.ip, req, 501, body.length);
             return;
         }
 
@@ -45,36 +79,44 @@ export function startHttpd(kernel: Kernel, opts: HttpOptions = {}): void {
                 "HTTP/1.1 403 Forbidden",
                 `Content-Length: ${body.length}`,
                 "Connection: close",
+                "Content-Type: text/plain",
                 "",
                 "",
             ].join("\r\n");
             conn.write(enc.encode(headers));
             if (req.method === "GET") conn.write(enc.encode(body));
+            await log(conn.ip, req, 403, body.length);
             return;
         }
 
         try {
             const data = await fs.readFile(full);
+            const ext = extname(full).toLowerCase();
+            const ct = mime[ext] || "application/octet-stream";
             const headers = [
                 "HTTP/1.1 200 OK",
                 `Content-Length: ${data.length}`,
                 "Connection: keep-alive",
+                `Content-Type: ${ct}`,
                 "",
                 "",
             ].join("\r\n");
             conn.write(enc.encode(headers));
             if (req.method === "GET") conn.write(data);
+            await log(conn.ip, req, 200, data.length);
         } catch {
             const body = "Not Found";
             const headers = [
                 "HTTP/1.1 404 Not Found",
                 `Content-Length: ${body.length}`,
                 "Connection: close",
+                "Content-Type: text/plain",
                 "",
                 "",
             ].join("\r\n");
             conn.write(enc.encode(headers));
             if (req.method === "GET") conn.write(enc.encode(body));
+            await log(conn.ip, req, 404, body.length);
         }
     };
 

--- a/core/services/ssh.test.ts
+++ b/core/services/ssh.test.ts
@@ -11,7 +11,9 @@ const dec = new TextDecoder();
 describe("SSH service", () => {
     it("spawns a shell after login", async () => {
         const tcp = new TCP();
-        const k1 = kernelTest!.createKernel(new InMemoryFileSystem());
+        const fs1 = new InMemoryFileSystem();
+        fs1.createFile("/etc/passwd", "user:pass\n", 0o644);
+        const k1 = kernelTest!.createKernel(fs1);
         const k2 = kernelTest!.createKernel(new InMemoryFileSystem());
         kernelTest!.getState(k1).tcp = tcp;
         kernelTest!.getState(k2).tcp = tcp;


### PR DESCRIPTION
## Summary
- verify SSH logins using `/etc/passwd` with optional key auth
- add MIME lookup, error pages and logging to HTTP daemon
- adjust SSH/HTTP tests for new behaviour

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684b884b9578832486523f86f15663c5