### PR TITLE
Add network and quota guard tests

### DIFF
--- a/core/kernel.test.ts
+++ b/core/kernel.test.ts
@@ -9,6 +9,7 @@ import {
     syscall_unlink,
     syscall_rename,
     syscall_readdir,
+    syscall_set_quota,
 } from "./kernel/syscalls";
 import * as fs from "fs/promises";
 import path from "path";
@@ -49,11 +50,23 @@ describe("Kernel", () => {
             kernelTest!.getState(kernel).fs.getNode("/mnt/foo.txt"),
             "file mounted",
         );
+        let mounts = await kernelTest!.getState(kernel).fs.read("/proc/mounts");
+        let text = new TextDecoder().decode(mounts);
+        assert(text.includes("/mnt"), "/proc/mounts lists mount");
+        await assert.rejects(
+            async () => {
+                await kernelTest!.syscall_mount(kernel, tmp, "/mnt");
+            },
+            /EEXIST/,
+        );
         await kernelTest!.syscall_unmount(kernel, "/mnt");
         assert(
             !kernelTest!.getState(kernel).fs.getNode("/mnt/foo.txt"),
             "file unmounted",
         );
+        mounts = await kernelTest!.getState(kernel).fs.read("/proc/mounts");
+        text = new TextDecoder().decode(mounts);
+        assert(text === "", "mounts cleared after unmount");
         await fs.unlink(tmp);
     });
 
@@ -436,6 +449,39 @@ describe("Kernel", () => {
             quotaPcb.exited,
             true,
             "process should exit when exceeding memory quota",
+        );
+    });
+
+    it("cpu quota kills runaway process", async () => {
+        globalThis.window = {} as any;
+        globalThis.window.crypto = {
+            getRandomValues: (arr: Uint32Array) =>
+                require("crypto").randomFillSync(arr),
+        };
+        const { mockIPC, clearMocks } = await import("@tauri-apps/api/mocks");
+        let calls = 0;
+        mockIPC(() => {
+            calls++;
+            return { running: true, cpu_ms: 3, mem_bytes: 0 };
+        });
+        const cpuKernel = kernelTest!.createKernel(new InMemoryFileSystem());
+        const cpuPid = await kernelTest!.syscall_spawn(cpuKernel, "dummy", {
+            quotaMs: 1,
+        });
+        const cpuPcb = kernelTest!
+            .getState(cpuKernel)
+            .processes.get(cpuPid)!;
+        syscall_set_quota.call(cpuKernel, cpuPcb, undefined, undefined, 5);
+        await kernelTest!.runProcess(cpuKernel, cpuPcb);
+        await kernelTest!.runProcess(cpuKernel, cpuPcb);
+        clearMocks();
+        // @ts-ignore
+        delete globalThis.window;
+        assert(calls >= 2);
+        assert.strictEqual(
+            cpuPcb.exited,
+            true,
+            "process exits after exceeding cpu quota",
         );
     });
 

--- a/core/nic.test.ts
+++ b/core/nic.test.ts
@@ -38,6 +38,17 @@ describe("NIC syscalls", () => {
         assert(r1.ip !== r2.ip, "addresses must be unique");
     });
 
+    it("dhcp increments leases", () => {
+        const k = kernelTest!.createKernel(new InMemoryFileSystem());
+        k.startNetworking();
+        kernelTest!.syscall_create_nic(k, "eth0", "AA:BB:CC:DD:EE:10");
+        kernelTest!.syscall_create_nic(k, "eth1", "AA:BB:CC:DD:EE:11");
+        const r1 = kernelTest!.syscall_dhcp_request(k, "eth0");
+        const r2 = kernelTest!.syscall_dhcp_request(k, "eth1");
+        assert.strictEqual(r1.ip, "10.0.0.2");
+        assert.strictEqual(r2.ip, "10.0.0.3");
+    });
+
     it("wifi scan and join", async () => {
         // @ts-ignore
         globalThis.window = {} as any;

--- a/core/routes.test.ts
+++ b/core/routes.test.ts
@@ -21,5 +21,21 @@ describe("Route syscalls", () => {
         router.forward(frame2);
         assert(nic1.rx.length === 1, "frame dropped after delete");
     });
+
+    it("route lookup uses first match", () => {
+        const k = kernelTest!.createKernel(new InMemoryFileSystem());
+        k.startNetworking();
+        kernelTest!.syscall_create_nic(k, "eth0", "AA");
+        kernelTest!.syscall_create_nic(k, "eth1", "BB");
+        kernelTest!.syscall_route_add(k, "192.168.1.0/24", "eth0");
+        kernelTest!.syscall_route_add(k, "192.168.0.0/16", "eth1");
+        const router = kernelTest!.getRouter(k);
+        const frame = { src: "10.0.0.1", dst: "192.168.1.55", payload: new Uint8Array([5]) };
+        router.forward(frame);
+        const nic0 = kernelTest!.getState(k).nics.get("eth0") as NIC;
+        const nic1 = kernelTest!.getState(k).nics.get("eth1") as NIC;
+        assert.strictEqual(nic0.rx.length, 1, "specific route chosen");
+        assert.strictEqual(nic1.rx.length, 0, "general route ignored");
+    });
 });
 


### PR DESCRIPTION
## Summary
- extend mount cycle test to check /proc/mounts and duplicate mounts
- add DHCP lease increment test
- verify router chooses first matching route
- cover CPU quota enforcement

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684b888ea9f0832495720905fa85dd7d