### PR TITLE
Implement /proc cmdline and ps CPU tracking

### DIFF
--- a/apps/cli/programs/ps.ts
+++ b/apps/cli/programs/ps.ts
@@ -3,14 +3,14 @@ import type { SyscallDispatcher } from "../../types/syscalls";
 export async function main(syscall: SyscallDispatcher): Promise<number> {
     const STDOUT_FD = 1;
     const encode = (s: string) => new TextEncoder().encode(s);
-    const procs: Array<{ pid: number; cpuMs: number; memBytes: number; tty?: string; argv?: string[] }> = await syscall('ps');
+    const procs: Array<{ pid: number; cpuMs: number; recentCpuMs: number; memBytes: number; tty?: string; argv?: string[] }> = await syscall('ps');
 
-    const totalCpu = procs.reduce((n, p) => n + (p.cpuMs || 0), 0);
+    const totalCpu = procs.reduce((n, p) => n + (p.recentCpuMs || 0), 0);
     const totalMem = procs.reduce((n, p) => n + (p.memBytes || 0), 0);
 
     let lines = 'PID %CPU %MEM TTY COMMAND\n';
     for (const p of procs) {
-        const cpu = totalCpu ? ((p.cpuMs || 0) / totalCpu * 100).toFixed(1) : '0.0';
+        const cpu = totalCpu ? ((p.recentCpuMs || 0) / totalCpu * 100).toFixed(1) : '0.0';
         const mem = totalMem ? ((p.memBytes || 0) / totalMem * 100).toFixed(1) : '0.0';
         const tty = p.tty ? p.tty : '?';
         const cmd = p.argv ? p.argv.join(' ') : '';

--- a/apps/types/syscalls.d.ts
+++ b/apps/types/syscalls.d.ts
@@ -32,7 +32,7 @@ export interface SyscallDispatcher {
     (call: "snapshot"): Promise<Snapshot>;
     (call: "save_snapshot" | "save_snapshot_named", name?: string): Promise<number>;
     (call: "load_snapshot_named", name: string): Promise<number>;
-    (call: "ps"): Promise<Array<{ pid: number; argv?: string[]; exited?: boolean; cpuMs: number; memBytes: number; tty?: string }>>;
+    (call: "ps"): Promise<Array<{ pid: number; argv?: string[]; exited?: boolean; cpuMs: number; recentCpuMs: number; memBytes: number; tty?: string }>>;
     (call: "jobs"): Promise<Array<{ id: number; pids: ProcessID[]; status: string }>>;
     (call: "window_owners"): Promise<Array<[number, ProcessID]>>;
     (call: "list_services"): Promise<Array<[string, { port: number; proto: string }]>>;

--- a/core/kernel.test.ts
+++ b/core/kernel.test.ts
@@ -83,6 +83,7 @@ describe("Kernel", () => {
             pcb.exitCode = 0;
             pcb.cpuMs += 5;
             pcb.memBytes += 1024;
+            pcb.cpuHistory.push(5);
             runs++;
             if (runs >= 2) pcb.exited = true;
         });
@@ -353,6 +354,20 @@ describe("Kernel", () => {
                 text.includes("pid:\t" + procPid),
             "status file readable",
         );
+        const cmdFd = await kernelTest!.syscall_open(
+            procKernel,
+            procPcb,
+            `/proc/${procPid}/cmdline`,
+            "r",
+        );
+        const cmdData = await kernelTest!.syscall_read(
+            procKernel,
+            procPcb,
+            cmdFd,
+            1024,
+        );
+        const cmdText = new TextDecoder().decode(cmdData);
+        assert.strictEqual(cmdText, "", "cmdline should return empty string");
         try {
             await kernelTest!.syscall_open(
                 procKernel,

--- a/core/kernel/index.ts
+++ b/core/kernel/index.ts
@@ -91,6 +91,7 @@ import {
     registerProcFd,
     removeProcFd,
     procStatus,
+    procCmdline,
     runProcess,
     registerJob,
     removeJob,
@@ -250,6 +251,7 @@ export class Kernel {
     private registerProcFd = registerProcFd;
     private removeProcFd = removeProcFd;
     private procStatus = procStatus;
+    private procCmdline = procCmdline;
     private updateProcMounts = updateProcMounts;
     private runProcess = runProcess;
     public registerJob = registerJob;
@@ -543,6 +545,7 @@ export class Kernel {
             const pcb = kernel.state.processes.get(pid)!;
             if (pcb.quotaMs_total === undefined) pcb.quotaMs_total = Infinity;
             if (pcb.started === undefined) pcb.started = false;
+            if (!Array.isArray(pcb.cpuHistory)) pcb.cpuHistory = [];
             for (const fd of pcb.fds.keys()) {
                 kernel.registerProcFd(pid, fd);
             }

--- a/core/kernel/syscalls.ts
+++ b/core/kernel/syscalls.ts
@@ -864,15 +864,20 @@ export function syscall_ps(this: Kernel) {
         argv?: string[];
         exited?: boolean;
         cpuMs: number;
+        recentCpuMs: number;
         memBytes: number;
         tty?: string;
     }> = [];
     for (const [pid, pcb] of this.state.processes.entries()) {
+        const recentCpuMs = Array.isArray(pcb.cpuHistory)
+            ? pcb.cpuHistory.reduce((n, v) => n + v, 0)
+            : 0;
         list.push({
             pid,
             argv: pcb.argv,
             exited: pcb.exited,
             cpuMs: pcb.cpuMs,
+            recentCpuMs,
             memBytes: pcb.memBytes,
             tty: pcb.tty,
         });


### PR DESCRIPTION
## Summary
- add `cpuHistory` to PCB and track recent slices
- expose `/proc/<pid>/cmdline`
- compute `recentCpuMs` in `ps` syscall
- display CPU % based on recent slices
- test `/proc` cmdline and ps resource accounting

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684b89aae0788324a3f1b53ea2869ace