### PR TITLE
Remove filesystem casts

### DIFF
--- a/core/fs/async.ts
+++ b/core/fs/async.ts
@@ -10,4 +10,27 @@ export interface AsyncFileSystem {
     rename(oldPath: string, newPath: string): Promise<void>;
     mount(image: FileSystemSnapshot, path: string): Promise<void>;
     unmount(path: string): Promise<void>;
+
+    /** Typed helper methods */
+    getNode(path: string): FileSystemNode | undefined;
+    createFile(
+        path: string,
+        data: string | Uint8Array,
+        permissions: Permissions,
+    ): FileSystemNode;
+    createDirectory(path: string, permissions: Permissions): FileSystemNode;
+    createVirtualFile(
+        path: string,
+        onRead: () => Uint8Array,
+        permissions: Permissions,
+    ): FileSystemNode;
+    createVirtualDirectory(
+        path: string,
+        permissions: Permissions,
+    ): FileSystemNode;
+    writeFile(path: string, data: Uint8Array): FileSystemNode;
+    readFile(path: string): Uint8Array;
+    listDirectory(path: string): FileSystemNode[];
+    remove(path: string): void;
+    snapshotSubtree?(path: string): FileSystemSnapshot;
 }

--- a/core/kernel/index.ts
+++ b/core/kernel/index.ts
@@ -557,9 +557,12 @@ export class Kernel {
 
     public allocatePty(): { id: number; master: string; slave: string } {
         const alloc = this.ptys.allocate();
-        const fs = this.state.fs as any;
-        if (!fs.getNode(alloc.master)) fs.createFile(alloc.master, new Uint8Array(), 0o666);
-        if (!fs.getNode(alloc.slave)) fs.createFile(alloc.slave, new Uint8Array(), 0o666);
+        if (!this.state.fs.getNode(alloc.master)) {
+            this.state.fs.createFile(alloc.master, new Uint8Array(), 0o666);
+        }
+        if (!this.state.fs.getNode(alloc.slave)) {
+            this.state.fs.createFile(alloc.slave, new Uint8Array(), 0o666);
+        }
         return alloc;
     }
 

--- a/core/kernel/syscalls.ts
+++ b/core/kernel/syscalls.ts
@@ -199,19 +199,11 @@ export async function syscall_open(
     const fullPath = resolvePath(pcb, path);
     if (fullPath === "/dev/ptmx") {
         const alloc = this.ptys.allocate();
-        if (!(this.state.fs as any).getNode(alloc.master)) {
-            (this.state.fs as any).createFile(
-                alloc.master,
-                new Uint8Array(),
-                0o666,
-            );
+        if (!this.state.fs.getNode(alloc.master)) {
+            this.state.fs.createFile(alloc.master, new Uint8Array(), 0o666);
         }
-        if (!(this.state.fs as any).getNode(alloc.slave)) {
-            (this.state.fs as any).createFile(
-                alloc.slave,
-                new Uint8Array(),
-                0o666,
-            );
+        if (!this.state.fs.getNode(alloc.slave)) {
+            this.state.fs.createFile(alloc.slave, new Uint8Array(), 0o666);
         }
         const fd = pcb.nextFd++;
         pcb.fds.set(fd, {
@@ -230,19 +222,11 @@ export async function syscall_open(
         const id = parseInt((ttyMatch || ptyMatch)![1], 10);
         if (!this.ptys.exists(id)) {
             const alloc = this.ptys.allocate();
-            if (!(this.state.fs as any).getNode(alloc.master)) {
-                (this.state.fs as any).createFile(
-                    alloc.master,
-                    new Uint8Array(),
-                    0o666,
-                );
+            if (!this.state.fs.getNode(alloc.master)) {
+                this.state.fs.createFile(alloc.master, new Uint8Array(), 0o666);
             }
-            if (!(this.state.fs as any).getNode(alloc.slave)) {
-                (this.state.fs as any).createFile(
-                    alloc.slave,
-                    new Uint8Array(),
-                    0o666,
-                );
+            if (!this.state.fs.getNode(alloc.slave)) {
+                this.state.fs.createFile(alloc.slave, new Uint8Array(), 0o666);
             }
         }
         const fd = pcb.nextFd++;
@@ -459,19 +443,11 @@ export async function syscall_spawn(
     pcb.started = false;
     if (opts.pty) {
         const alloc = this.ptys.allocate();
-        if (!(this.state.fs as any).getNode(alloc.master)) {
-            (this.state.fs as any).createFile(
-                alloc.master,
-                new Uint8Array(),
-                0o666,
-            );
+        if (!this.state.fs.getNode(alloc.master)) {
+            this.state.fs.createFile(alloc.master, new Uint8Array(), 0o666);
         }
-        if (!(this.state.fs as any).getNode(alloc.slave)) {
-            (this.state.fs as any).createFile(
-                alloc.slave,
-                new Uint8Array(),
-                0o666,
-            );
+        if (!this.state.fs.getNode(alloc.slave)) {
+            this.state.fs.createFile(alloc.slave, new Uint8Array(), 0o666);
         }
         pcb.tty = alloc.slave;
     } else if (opts.tty !== undefined) {
@@ -636,7 +612,7 @@ export async function syscall_mkdir(
 ): Promise<number> {
     const fullPath = resolvePath(pcb, path);
     const parentPath = getParentPath(fullPath);
-    const parent = (this.state.fs as any).getNode(parentPath);
+    const parent = this.state.fs.getNode(parentPath);
     if (parent) {
         const perm = parent.permissions;
         let rights = 0;
@@ -667,7 +643,7 @@ export async function syscall_readdir(
     path: string,
 ): Promise<FileSystemNode[]> {
     const fullPath = resolvePath(pcb, path);
-    const node = (this.state.fs as any).getNode(fullPath);
+    const node = this.state.fs.getNode(fullPath);
     if (node) {
         const perm = node.permissions;
         let rights = 0;
@@ -697,7 +673,7 @@ export async function syscall_unlink(
     path: string,
 ): Promise<number> {
     const fullPath = resolvePath(pcb, path);
-    const node = (this.state.fs as any).getNode(fullPath);
+    const node = this.state.fs.getNode(fullPath);
     if (node) {
         const perm = node.permissions;
         let rights = 0;
@@ -729,7 +705,7 @@ export async function syscall_rename(
     newPath: string,
 ): Promise<number> {
     const oldFull = resolvePath(pcb, oldPath);
-    const node = (this.state.fs as any).getNode(oldFull);
+    const node = this.state.fs.getNode(oldFull);
     if (node) {
         const perm = node.permissions;
         let rights = 0;
@@ -804,11 +780,8 @@ export async function syscall_unmount(
     };
     const file = kernelWithVolumes.mountedVolumes.get(mountPoint);
     let snap: FileSystemSnapshot | undefined;
-    const fsAny = this.state.fs as unknown as {
-        snapshotSubtree?: (p: string) => FileSystemSnapshot;
-    };
-    if (file && fsAny.snapshotSubtree) {
-        snap = fsAny.snapshotSubtree(mountPoint);
+    if (file && this.state.fs.snapshotSubtree) {
+        snap = this.state.fs.snapshotSubtree(mountPoint);
     }
 
     await this.state.fs.unmount(mountPoint);


### PR DESCRIPTION
## Summary
- expose typed helpers on `AsyncFileSystem`
- use the helpers in kernel syscalls and process management
- avoid `(fs as any)` casts

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684b897579bc83249e8d1f7064ef30f6