### PR TITLE
Implement DHCP server and async client

### DIFF
--- a/core/kernel/index.ts
+++ b/core/kernel/index.ts
@@ -45,7 +45,7 @@ function maskBits(mask: string): number {
         );
 }
 
-function networkFrom(ip: string, mask: string): string {
+export function networkFrom(ip: string, mask: string): string {
     const netInt = ipToInt(ip) & ipToInt(mask);
     const parts = [
         (netInt >>> 24) & 0xff,


### PR DESCRIPTION
## Summary
- add DHCP server state on the host
- handle `dhcp_request` in the host and expose it via Tauri
- expose `networkFrom` from kernel and use it when requesting DHCP
- make `syscall_dhcp_request` asynchronous
- update NIC tests for new async behaviour

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684b86b30eb8832487771f93ce2bf508