### PR TITLE
Remove fs casts via typed helpers

### DIFF
--- a/core/fs/async.ts
+++ b/core/fs/async.ts
@@ -10,4 +10,25 @@ export interface AsyncFileSystem {
     rename(oldPath: string, newPath: string): Promise<void>;
     mount(image: FileSystemSnapshot, path: string): Promise<void>;
     unmount(path: string): Promise<void>;
+
+    // Typed helpers used by the kernel
+    getNode(path: string): FileSystemNode | undefined;
+    createFile(
+        path: string,
+        data: string | Uint8Array,
+        permissions: Permissions,
+    ): FileSystemNode;
+    createDirectory(path: string, permissions: Permissions): FileSystemNode;
+    createVirtualFile(
+        path: string,
+        onRead: () => Uint8Array | FileSystemNode[],
+        permissions: Permissions,
+    ): FileSystemNode;
+    createVirtualDirectory(path: string, permissions: Permissions): FileSystemNode;
+    writeFile(path: string, data: Uint8Array): FileSystemNode;
+    readFile(path: string): Uint8Array;
+    listDirectory(path: string): FileSystemNode[];
+    remove(path: string): void;
+    getSnapshot(): FileSystemSnapshot;
+    clone(): AsyncFileSystem;
 }

--- a/core/kernel/syscalls.ts
+++ b/core/kernel/syscalls.ts
@@ -10,7 +10,7 @@ import {
     loadNamedSnapshot,
 } from "../fs/sqlite";
 import type { FileSystemNode, FileSystemSnapshot } from "../fs";
-import type { AsyncFileSystem } from "../fs/async";
+import type { FileSystem } from "../fs";
 import type { Kernel, KernelState, WindowOpts, Snapshot } from "./index";
 import { networkFrom } from "./index";
 import type { ProcessControlBlock, FileDescriptor, ProcessID } from "./process";
@@ -228,19 +228,11 @@ async function openPty(
 ): Promise<FileDescriptor> {
     if (fullPath === "/dev/ptmx") {
         const alloc = this.ptys.allocate();
-        if (!(this.state.fs as any).getNode(alloc.master)) {
-            (this.state.fs as any).createFile(
-                alloc.master,
-                new Uint8Array(),
-                0o666,
-            );
+        if (!this.state.fs.getNode(alloc.master)) {
+            this.state.fs.createFile(alloc.master, new Uint8Array(), 0o666);
         }
-        if (!(this.state.fs as any).getNode(alloc.slave)) {
-            (this.state.fs as any).createFile(
-                alloc.slave,
-                new Uint8Array(),
-                0o666,
-            );
+        if (!this.state.fs.getNode(alloc.slave)) {
+            this.state.fs.createFile(alloc.slave, new Uint8Array(), 0o666);
         }
         const fd = pcb.nextFd++;
         pcb.fds.set(fd, {
@@ -259,19 +251,11 @@ async function openPty(
     const id = parseInt((ttyMatch || ptyMatch)![1], 10);
     if (!this.ptys.exists(id)) {
         const alloc = this.ptys.allocate();
-        if (!(this.state.fs as any).getNode(alloc.master)) {
-            (this.state.fs as any).createFile(
-                alloc.master,
-                new Uint8Array(),
-                0o666,
-            );
+        if (!this.state.fs.getNode(alloc.master)) {
+            this.state.fs.createFile(alloc.master, new Uint8Array(), 0o666);
         }
-        if (!(this.state.fs as any).getNode(alloc.slave)) {
-            (this.state.fs as any).createFile(
-                alloc.slave,
-                new Uint8Array(),
-                0o666,
-            );
+        if (!this.state.fs.getNode(alloc.slave)) {
+            this.state.fs.createFile(alloc.slave, new Uint8Array(), 0o666);
         }
     }
     const fd = pcb.nextFd++;
@@ -495,19 +479,11 @@ export async function syscall_spawn(
     pcb.started = false;
     if (opts.pty) {
         const alloc = this.ptys.allocate();
-        if (!(this.state.fs as any).getNode(alloc.master)) {
-            (this.state.fs as any).createFile(
-                alloc.master,
-                new Uint8Array(),
-                0o666,
-            );
+        if (!this.state.fs.getNode(alloc.master)) {
+            this.state.fs.createFile(alloc.master, new Uint8Array(), 0o666);
         }
-        if (!(this.state.fs as any).getNode(alloc.slave)) {
-            (this.state.fs as any).createFile(
-                alloc.slave,
-                new Uint8Array(),
-                0o666,
-            );
+        if (!this.state.fs.getNode(alloc.slave)) {
+            this.state.fs.createFile(alloc.slave, new Uint8Array(), 0o666);
         }
         pcb.tty = alloc.slave;
     } else if (opts.tty !== undefined) {
@@ -672,7 +648,7 @@ export async function syscall_mkdir(
 ): Promise<number> {
     const fullPath = resolvePath(pcb, path);
     const parentPath = getParentPath(fullPath);
-    const parent = (this.state.fs as any).getNode(parentPath);
+    const parent = this.state.fs.getNode(parentPath);
     if (parent) {
         const perm = parent.permissions;
         let rights = 0;
@@ -703,7 +679,7 @@ export async function syscall_readdir(
     path: string,
 ): Promise<FileSystemNode[]> {
     const fullPath = resolvePath(pcb, path);
-    const node = (this.state.fs as any).getNode(fullPath);
+    const node = this.state.fs.getNode(fullPath);
     if (node) {
         const perm = node.permissions;
         let rights = 0;
@@ -733,7 +709,7 @@ export async function syscall_unlink(
     path: string,
 ): Promise<number> {
     const fullPath = resolvePath(pcb, path);
-    const node = (this.state.fs as any).getNode(fullPath);
+    const node = this.state.fs.getNode(fullPath);
     if (node) {
         const perm = node.permissions;
         let rights = 0;
@@ -765,7 +741,7 @@ export async function syscall_rename(
     newPath: string,
 ): Promise<number> {
     const oldFull = resolvePath(pcb, oldPath);
-    const node = (this.state.fs as any).getNode(oldFull);
+    const node = this.state.fs.getNode(oldFull);
     if (node) {
         const perm = node.permissions;
         let rights = 0;

--- a/ui/components/Terminal.tsx
+++ b/ui/components/Terminal.tsx
@@ -31,8 +31,7 @@ const Terminal = forwardRef<TerminalHandles, TerminalProps>(({ kernel }, ref) =>
     useEffect(() => {
         async function loadSettings() {
             try {
-                const fs = (kernel as any).state.fs as any;
-                const data: Uint8Array = await fs.read("/etc/input.json");
+                const data: Uint8Array = await kernel.state.fs.read("/etc/input.json");
                 const text = new TextDecoder().decode(data);
                 const cfg = JSON.parse(text) as {
                     fontFamily?: string;


### PR DESCRIPTION
## Summary
- expose extra helper methods on `AsyncFileSystem`
- use typed filesystem in kernel
- remove `(fs as any)` casts in kernel and UI
- provide minimal implementations for persistent backend

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684b8d7079d883249ce262ba2cede85c